### PR TITLE
Update API title from KRAIL to KRAIL-CONFIG in OpenAPI schema

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "KRAIL Schema API",
+    "title": "KRAIL-CONFIG Schema API",
     "version": "1.0.0"
   },
   "paths": {},

--- a/scripts/generate-openapi.cjs
+++ b/scripts/generate-openapi.cjs
@@ -29,7 +29,7 @@ const YAML = require("yaml");
   const openapi = {
     openapi: "3.0.3",
     info: {
-      title: "KRAIL Schema API",
+      title: "KRAIL-CONFIG Schema API",
       version: "1.0.0",
     },
     paths: {},


### PR DESCRIPTION
### TL;DR

Updated the API title from "KRAIL Schema API" to "KRAIL-CONFIG Schema API" in OpenAPI documentation.

### What changed?

Modified the API title in two files:
- `docs/openapi.json`: Changed title from "KRAIL Schema API" to "KRAIL-CONFIG Schema API"
- `scripts/generate-openapi.cjs`: Updated the same title in the OpenAPI generation script

### How to test?

1. Verify that the OpenAPI documentation correctly displays "KRAIL-CONFIG Schema API" as the title
2. Run the OpenAPI generation script to confirm it produces the updated title
3. Check that any UI components or documentation referencing the API title show the new name

### Why make this change?

This change provides more specific naming for the API, clearly indicating that it's related to the configuration aspect of KRAIL. The more descriptive title helps users better understand the purpose and scope of this particular API.