### PR TITLE
Add KRAIL Config Schema documentation and remove openapi.yaml from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,3 @@ yarn-error.log*
 
 # OS
 Thumbs.db
-
-# Optional if using Swagger/OpenAPI
-openapi.yaml

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Karan Sharma
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# KRAIL Config Schema Docs
+
+This repository contains JSON schemas for KRAIL app configuration and a workflow to generate OpenAPI specification documentation from those schemas.
+
+---
+
+## What’s in this repo?
+
+- `src/` — Folder containing JSON schema files (`*.schema.json`) describing configuration data.
+- `scripts/generate-openapi.js` — Node.js script that converts JSON schemas into a combined OpenAPI 3.0 spec (`openapi.yaml` and `openapi.json`).
+- `docs/` — Folder containing generated OpenAPI specs and documentation assets (served by GitHub Pages).
+- `.github/workflows/generate-openapi.yml` — GitHub Actions workflow to automatically regenerate and commit the OpenAPI spec on schema changes.
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/en/download/) (v16 or higher recommended)
+- `npm` (comes with Node.js)
+- Git
+
+---
+
+### Installation
+
+Clone the repo and install dependencies:
+
+```bash
+git clone https://github.com/yourusername/KRAIL-CONFIG.git
+cd KRAIL-CONFIG
+npm install
+```
+
+## Generating OpenAPI docs locally
+
+To generate the OpenAPI spec files (openapi.yaml and openapi.json) from all JSON schemas:
+
+```bash
+npm run generate:openapi
+```
+
+This will:
+- Read all .schema.json files under src/
+- Convert them to OpenAPI schema components
+- Output openapi.yaml and openapi.json files inside the docs/ folder
+
+## Viewing the documentation
+The generated OpenAPI spec can be visualized using:
+
+- Swagger Editor: Paste the contents of docs/openapi.yaml or docs/openapi.json.
+- Local Swagger UI or Redoc server.
+- GitHub Pages, if you have the docs/ folder configured as your GitHub Pages source.
+
+## Automating generation on push
+The GitHub Actions workflow .github/workflows/generate-openapi.yml automatically:
+
+- Runs on pushes to the main branch.
+- Regenerates openapi.yaml and openapi.json whenever JSON schema files or the generator script changes.
+- Commits and pushes updated OpenAPI specs to the docs/ folder.
+
+This keeps the OpenAPI docs up to date with minimal manual work.
+
+## Customization
+Add or remove JSON schemas in the src/ folder to modify the API schema.
+
+## Development Tips
+
+- Keep your JSON schema files under src/ with a .schema.json extension.
+- Use JSON Schema Draft-07 compatible syntax.
+- Run npm run generate:openapi after schema edits to preview changes locally before pushing.
+
+## Troubleshooting
+- If you get missing module errors (yaml, fast-glob, etc.), run:
+```bash
+npm install
+```
+- Ensure node_modules/ is in .gitignore and not committed.
+- If GitHub Pages fails to serve docs, confirm your repository’s Pages source is set to the /docs folder.
+
+## License
+
+This project is licensed under the Apache License. See `LICENSE` file for more details.
+
+---
+
+## Contact
+
+If you have any questions or feedback, feel free to raise an issue or reach out to the maintainers.
+
+Email: hey@krail.app

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: KRAIL-CONFIG Schema API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    notice:
+      title: NoticeConfig
+      type: object
+      properties:
+        noticeList:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              title:
+                type: string
+              description:
+                type: string
+              heroImageUrl:
+                type: string
+              ctaText:
+                type: string
+                nullable: true
+              ctaUrl:
+                type: string
+                nullable: true
+              shareUrl:
+                type: string
+                nullable: true
+            required:
+              - type
+              - title
+              - description
+              - heroImageUrl
+      required:
+        - noticeList


### PR DESCRIPTION
# Add KRAIL Config Schema Documentation

### TL;DR

Set up a repository for KRAIL configuration schemas with OpenAPI documentation generation.

### What changed?

- Created a comprehensive README.md with documentation about the repository structure and usage
- Added OpenAPI schema documentation in YAML format
- Updated LICENSE file with copyright information (Karan Sharma, 2025)
- Removed `openapi.yaml` from .gitignore since it's now tracked in the docs directory

### How to test?

1. Clone the repository
2. Run `npm install` to set up dependencies
3. Execute `npm run generate:openapi` to verify the OpenAPI generation works
4. Check that the documentation in the `docs/` folder is properly formatted

### Why make this change?

This change establishes the foundation for documenting KRAIL app configuration schemas. By using JSON Schema with OpenAPI generation, we create a standardized way to document configuration options that can be automatically updated and published. This will help developers understand available configuration options and improve the developer experience when working with KRAIL apps.