### PR TITLE
Move OpenAPI spec to docs directory and update references

### DIFF
--- a/.github/workflows/schema-docs.yml
+++ b/.github/workflows/schema-docs.yml
@@ -49,8 +49,11 @@ jobs:
             cat "$schema" | jq '.' | sed 's/^/      /' >> openapi.yaml
           done
 
+      - name: Move OpenAPI spec to docs
+        run: mv openapi.yaml docs/openapi.yaml
+
       - name: Build Redoc docs
-        run: npx @redocly/cli build-docs openapi.yaml -o docs/index.html
+        run: npx @redocly/cli build-docs docs/openapi.yaml -o docs/index.html
 
       - name: Upload docs to GitHub Pages
         uses: actions/upload-pages-artifact@v3

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
 <script>
     window.onload = () => {
       SwaggerUIBundle({
-        url: './openapi.json',
+        url: './openapi.yaml',
         dom_id: '#swagger-ui',
       });
     };


### PR DESCRIPTION
### TL;DR

Updated the schema documentation workflow to properly handle the OpenAPI specification file.

### What changed?

- Added a new step in the GitHub workflow to move the generated OpenAPI spec to the docs directory
- Updated the build-docs command to reference the OpenAPI spec from the docs directory
- Modified the Swagger UI configuration in docs/index.html to load the YAML file instead of JSON

### How to test?

1. Run the schema-docs workflow manually or trigger it with a relevant change
2. Verify that the OpenAPI spec is correctly moved to the docs directory
3. Check that the documentation builds successfully and the Swagger UI loads the YAML file

### Why make this change?

This change ensures that the OpenAPI specification is properly stored in the docs directory alongside the generated documentation, making it easier to access and reference. It also fixes the file extension in the Swagger UI configuration to match the actual format of the generated specification file (YAML instead of JSON).