### PR TITLE
Add debug logging to schema-docs workflow

### DIFF
--- a/.github/workflows/schema-docs.yml
+++ b/.github/workflows/schema-docs.yml
@@ -49,11 +49,20 @@ jobs:
             cat "$schema" | jq '.' | sed 's/^/      /' >> openapi.yaml
           done
 
+      - name: List files after OpenAPI generation
+        run: ls -l
+
       - name: Move OpenAPI spec to docs
         run: mv openapi.yaml docs/openapi.yaml
 
+      - name: List files in docs after move
+        run: ls -l docs
+
       - name: Build Redoc docs
         run: npx @redocly/cli build-docs docs/openapi.yaml -o docs/index.html
+
+      - name: List files in docs after Redoc build
+        run: ls -l docs
 
       - name: Upload docs to GitHub Pages
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
### TL;DR

Added debugging steps to the schema-docs workflow to improve visibility into the file generation process.

### What changed?

Added three `ls -l` commands to the schema-docs GitHub workflow:
- After OpenAPI generation to verify the file was created
- After moving the OpenAPI spec to the docs directory
- After building the Redoc documentation

### How to test?

Run the schema-docs workflow and check the logs to ensure the file listing steps execute correctly and show the expected files at each stage of the process.

### Why make this change?

These debugging steps provide better visibility into the workflow execution, making it easier to troubleshoot issues with file generation and placement. This helps ensure that the OpenAPI spec and documentation are properly created and moved to the correct locations before being published to GitHub Pages.