### PR TITLE
Install ajv-cli in schema-docs workflow

### DIFF
--- a/.github/workflows/schema-docs.yml
+++ b/.github/workflows/schema-docs.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install Tools
+        run: |
+          npm install -g ajv-cli
+
       - name: Validate all JSON files
         run: |
           find src -name '*.schema.json' | while read schema; do


### PR DESCRIPTION
### TL;DR

Added installation of ajv-cli in the schema-docs workflow.

### What changed?

Added a new step in the GitHub workflow that installs the ajv-cli tool globally using npm before validating JSON schema files. This ensures the necessary validation tool is available during the workflow execution.

### How to test?

1. Run the schema-docs workflow manually to verify that ajv-cli is properly installed
2. Confirm that the JSON schema validation step completes successfully

### Why make this change?

The workflow was likely failing because it was trying to validate JSON schema files without having the required validation tool (ajv-cli) installed. This change ensures the proper dependencies are in place before validation begins.