### PR TITLE
Add holiday dates and simplify park ride facility names

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -241,6 +241,374 @@
                 "🎉"
               ],
               "greeting": "Happy New Year"
+            },
+            {
+              "type": "NEW_YEAR_EVE",
+              "month": 12,
+              "day": 31,
+              "emojiList": [
+                "🎆"
+              ],
+              "greeting": "New Year's Eve"
+            },
+            {
+              "type": "ANZAC_DAY",
+              "month": 4,
+              "day": 25,
+              "emojiList": [
+                "🌺",
+                "🇦🇺",
+                "🎖️"
+              ],
+              "greeting": "Lest we forget"
+            },
+            {
+              "type": "HALLOWEEN",
+              "month": 10,
+              "day": 31,
+              "emojiList": [
+                "🎃",
+                "👻"
+              ],
+              "greeting": "Spooktacular vibes only!"
+            },
+            {
+              "type": "ROSE_DAY",
+              "month": 2,
+              "day": 7,
+              "emojiList": [
+                "🌹"
+              ],
+              "greeting": "Rose Day"
+            },
+            {
+              "type": "PROPOSE_DAY",
+              "month": 2,
+              "day": 8,
+              "emojiList": [
+                "💍",
+                "💞",
+                "💌"
+              ],
+              "greeting": "Propose Day"
+            },
+            {
+              "type": "CHOCOLATE_DAY",
+              "month": 2,
+              "day": 9,
+              "emojiList": [
+                "🍫",
+                "💞"
+              ],
+              "greeting": "Chocolate Day"
+            },
+            {
+              "type": "TEDDY_DAY",
+              "month": 2,
+              "day": 10,
+              "emojiList": [
+                "🧸"
+              ],
+              "greeting": "Teddy Day"
+            },
+            {
+              "type": "PROMISE_DAY",
+              "month": 2,
+              "day": 11,
+              "emojiList": [
+                "🤝"
+              ],
+              "greeting": "Promise Day"
+            },
+            {
+              "type": "HUG_DAY",
+              "month": 2,
+              "day": 12,
+              "emojiList": [
+                "🤗"
+              ],
+              "greeting": "Hug Day"
+            },
+            {
+              "type": "KISS_DAY",
+              "month": 2,
+              "day": 13,
+              "emojiList": [
+                "😘"
+              ],
+              "greeting": "Kiss Day"
+            },
+            {
+              "type": "VALENTINES_DAY",
+              "month": 2,
+              "day": 14,
+              "emojiList": [
+                "❤️",
+                "🌹"
+              ],
+              "greeting": "Love is in the air"
+            },
+            {
+              "type": "AUSTRALIA_DAY",
+              "month": 1,
+              "day": 26,
+              "emojiList": [
+                "🇦🇺",
+                "🎉",
+                "🎆"
+              ],
+              "greeting": "Australia Day"
+            },
+            {
+              "type": "WOMENS_DAY",
+              "month": 3,
+              "day": 8,
+              "emojiList": [
+                "💜",
+                "♀️",
+                "👩",
+                "👩‍🚀",
+                "👩‍🚒",
+                "👩‍✈️"
+              ],
+              "greeting": "International Women's Day"
+            },
+            {
+              "type": "MENS_DAY",
+              "month": 11,
+              "day": 19,
+              "emojiList": [
+                "💙",
+                "♂️",
+                "🚹",
+                "👨‍🚒",
+                "👨‍🌾",
+                "👨‍🚀"
+              ],
+              "greeting": "International Men's Day"
+            },
+            {
+              "type": "ENGINEERS_DAY",
+              "month": 9,
+              "day": 15,
+              "emojiList": [
+                "⚙️",
+                "🔧"
+              ],
+              "greeting": "Engineers Day"
+            },
+            {
+              "type": "NURSES_DAY",
+              "month": 5,
+              "day": 12,
+              "emojiList": [
+                "🏥",
+                "🩺"
+              ],
+              "greeting": "Nurses Day"
+            },
+            {
+              "type": "FRIENDSHIP_DAY",
+              "month": 8,
+              "day": 3,
+              "emojiList": [
+                "🤝",
+                "💛"
+              ],
+              "greeting": "Friendship Day"
+            },
+            {
+              "type": "PEACE_DAY",
+              "month": 9,
+              "day": 21,
+              "emojiList": [
+                "☮️",
+                "✌️"
+              ],
+              "greeting": "International Peace Day"
+            },
+            {
+              "type": "A11Y_DAY",
+              "month": 5,
+              "day": 16,
+              "emojiList": [
+                "♿️"
+              ],
+              "greeting": "Global Accessibility Awareness Day"
+            },
+            {
+              "type": "PI_DAY",
+              "month": 3,
+              "day": 14,
+              "emojiList": [
+                "🥧",
+                "π"
+              ],
+              "greeting": "Pi Day"
+            },
+            {
+              "type": "INTERNATIONAL_YOGA_DAY",
+              "month": 6,
+              "day": 21,
+              "emojiList": [
+                "🧘",
+                "🧘‍♀️",
+                "🧘‍♂️",
+                "🕉️"
+              ],
+              "greeting": "International Yoga Day"
+            },
+            {
+              "type": "WORLD_ENVIRONMENT_DAY",
+              "month": 6,
+              "day": 5,
+              "emojiList": [
+                "🌍",
+                "🌱",
+                "🌳"
+              ],
+              "greeting": "World Environment Day"
+            },
+            {
+              "type": "MENTAL_HEALTH_DAY",
+              "month": 10,
+              "day": 10,
+              "emojiList": [
+                "🧠"
+              ],
+              "greeting": "World Mental Health Day"
+            },
+            {
+              "type": "WORLD_OCEANS_DAY",
+              "month": 6,
+              "day": 8,
+              "emojiList": [
+                "🌊",
+                "🐬",
+                "🐠"
+              ],
+              "greeting": "World Oceans Day"
+            },
+            {
+              "type": "STAR_WARS_DAY",
+              "month": 5,
+              "day": 4,
+              "emojiList": [
+                "🌌",
+                "🚀",
+                "⚔️",
+                "🪐"
+              ],
+              "greeting": "May the Force Ride With You"
+            },
+            {
+              "type": "MARIO_DAY",
+              "month": 3,
+              "day": 10,
+              "emojiList": [
+                "🍄",
+                "🎮"
+              ],
+              "greeting": "It's-a me, Mario! Let's-a go! 🍄"
+            },
+            {
+              "type": "HOBBIT_DAY",
+              "month": 9,
+              "day": 22,
+              "emojiList": [
+                "🧙",
+                "🍄",
+                "🌋"
+              ],
+              "greeting": "Happy Hobbit Day"
+            },
+            {
+              "type": "HARRY_POTTER_DAY",
+              "month": 5,
+              "day": 2,
+              "emojiList": [
+                "🪄",
+                "🧙‍♂️",
+                "⚡️"
+              ],
+              "greeting": "Hop on Platform 9¾ — Magic Awaits!"
+            },
+            {
+              "type": "POKEMON_DAY",
+              "month": 2,
+              "day": 27,
+              "emojiList": [
+                "🎮",
+                "🧢",
+                "⚡️"
+              ],
+              "greeting": "Gotta Catch 'Em All"
+            },
+            {
+              "type": "BARBIE_DAY",
+              "month": 3,
+              "day": 9,
+              "emojiList": [
+                "👠",
+                "💖",
+                "👗",
+                "🎀"
+              ],
+              "greeting": "Be anything. Go everywhere. 💖"
+            },
+            {
+              "type": "TEACHERS_DAY",
+              "month": 9,
+              "day": 5,
+              "emojiList": [
+                "👩‍🏫",
+                "👨‍🏫",
+                "📚"
+              ],
+              "greeting": "Happy Teachers' Day"
+            },
+            {
+              "type": "WORLD_EMOJI_DAY",
+              "month": 7,
+              "day": 17,
+              "emojiList": [
+                "😎",
+                "🤩",
+                "🔥"
+              ],
+              "greeting": "World Emoji Day"
+            },
+            {
+              "type": "INTERNATIONAL_CAT_DAY",
+              "month": 8,
+              "day": 8,
+              "emojiList": [
+                "😸",
+                "😻"
+              ],
+              "greeting": "Purrfect day to ride"
+            },
+            {
+              "type": "INTERNATIONAL_DOG_DAY",
+              "month": 8,
+              "day": 26,
+              "emojiList": [
+                "🐶",
+                "🐾",
+                "🦴"
+              ],
+              "greeting": "International Dog Day"
+            },
+            {
+              "type": "TAYLOR_SWIFT_DAY",
+              "month": 12,
+              "day": 13,
+              "emojiList": [
+                "🎤",
+                "🎶",
+                "🩷"
+              ],
+              "greeting": "Happy Taylor Swift Day"
             }
           ],
           "variableDates": [
@@ -264,6 +632,82 @@
                 "🕌"
               ],
               "greeting": "Eid Mubarak!"
+            },
+            {
+              "type": "CHINESE_NEW_YEAR",
+              "startDate": "2026-02-17",
+              "endDate": "2026-03-03",
+              "emojiList": [
+                "🧧"
+              ],
+              "greeting": "Chinese New Year"
+            },
+            {
+              "type": "VIVID_SYDNEY",
+              "startDate": "2026-05-22",
+              "endDate": "2026-06-13",
+              "emojiList": [
+                "🎆",
+                "🌈",
+                "🌟",
+                "✨"
+              ],
+              "greeting": "Vivid Sydney"
+            },
+            {
+              "type": "MARDI_GRAS",
+              "startDate": "2026-02-13",
+              "endDate": "2026-03-01",
+              "emojiList": [
+                "🏳️‍🌈",
+                "🪩",
+                "🌈"
+              ],
+              "greeting": "Happy Mardi Gras"
+            },
+            {
+              "type": "NAIDOC_WEEK",
+              "startDate": "2025-07-06",
+              "endDate": "2025-07-13",
+              "emojiList": [
+                "🖤",
+                "💛",
+                "❤️"
+              ],
+              "greeting": "NAIDOC Week"
+            },
+            {
+              "type": "HOLI",
+              "startDate": "2025-03-14",
+              "endDate": "2025-03-14",
+              "emojiList": [
+                "🌈",
+                "🫧",
+                "🎈"
+              ],
+              "greeting": "Happy Holi"
+            },
+            {
+              "type": "MELBOURNE_CUP",
+              "startDate": "2025-11-04",
+              "endDate": "2025-11-04",
+              "emojiList": [
+                "🐎",
+                "💸"
+              ],
+              "greeting": "Melbourne Cup Day"
+            },
+            {
+              "type": "RECONCILIATION_WEEK",
+              "startDate": "2026-05-27",
+              "endDate": "2026-06-03",
+              "emojiList": [
+                "🪃",
+                "🖤",
+                "💛",
+                "❤️"
+              ],
+              "greeting": "Reconciliation Week"
             }
           ]
         }
@@ -426,22 +870,237 @@
           {
             "stopId": "213110",
             "parkRideFacilityId": "486",
-            "parkRideName": "Park&Ride - Ashfield"
+            "parkRideName": "Ashfield"
           },
           {
             "stopId": "2153478",
             "parkRideFacilityId": "31",
-            "parkRideName": "Park&Ride - Bella Vista"
+            "parkRideName": "Bella Vista"
           },
           {
             "stopId": "220910",
             "parkRideFacilityId": "35",
-            "parkRideName": "Park&Ride - Beverly Hills"
+            "parkRideName": "Beverly Hills"
           },
           {
             "stopId": "210017",
             "parkRideFacilityId": "490",
-            "parkRideName": "Park&Ride - Brookvale"
+            "parkRideName": "Brookvale"
+          },
+          {
+            "stopId": "256020",
+            "parkRideFacilityId": "19",
+            "parkRideName": "Campbelltown Farrow Rd (north)"
+          },
+          {
+            "stopId": "256020",
+            "parkRideFacilityId": "20",
+            "parkRideName": "Campbelltown Hurley St"
+          },
+          {
+            "stopId": "2126158",
+            "parkRideFacilityId": "33",
+            "parkRideName": "Cherrybrook"
+          },
+          {
+            "stopId": "209913",
+            "parkRideFacilityId": "13",
+            "parkRideName": "Dee Why"
+          },
+          {
+            "stopId": "217426",
+            "parkRideFacilityId": "17",
+            "parkRideName": "Edmondson Park (south)"
+          },
+          {
+            "stopId": "275020",
+            "parkRideFacilityId": "36",
+            "parkRideName": "Emu Plains"
+          },
+          {
+            "stopId": "207210",
+            "parkRideFacilityId": "6",
+            "parkRideName": "Gordon Henry St (north)"
+          },
+          {
+            "stopId": "225041",
+            "parkRideFacilityId": "8",
+            "parkRideName": "Gosford"
+          },
+          {
+            "stopId": "225040",
+            "parkRideFacilityId": "8",
+            "parkRideName": "Gosford"
+          },
+          {
+            "stopId": "2154392",
+            "parkRideFacilityId": "32",
+            "parkRideName": "Hills Showground"
+          },
+          {
+            "stopId": "207720",
+            "parkRideFacilityId": "25",
+            "parkRideName": "Hornsby"
+          },
+          {
+            "stopId": "207763",
+            "parkRideFacilityId": "25",
+            "parkRideName": "Hornsby"
+          },
+          {
+            "stopId": "2155382",
+            "parkRideFacilityId": "29",
+            "parkRideName": "Kellyville (north)"
+          },
+          {
+            "stopId": "2155382",
+            "parkRideFacilityId": "30",
+            "parkRideName": "Kellyville (south)"
+          },
+          {
+            "stopId": "253330",
+            "parkRideFacilityId": "7",
+            "parkRideName": "Kiama"
+          },
+          {
+            "stopId": "221710",
+            "parkRideFacilityId": "487",
+            "parkRideName": "Kogarah"
+          },
+          {
+            "stopId": "217933",
+            "parkRideFacilityId": "16",
+            "parkRideName": "Leppington"
+          },
+          {
+            "stopId": "207010",
+            "parkRideFacilityId": "34",
+            "parkRideName": "Lindfield Village Green"
+          },
+          {
+            "stopId": "209325",
+            "parkRideFacilityId": "489",
+            "parkRideName": "Manly Vale"
+          },
+          {
+            "stopId": "209324",
+            "parkRideFacilityId": "489",
+            "parkRideName": "Manly Vale"
+          },
+          {
+            "stopId": "2103108",
+            "parkRideFacilityId": "12",
+            "parkRideName": "Mona Vale"
+          },
+          {
+            "stopId": "210318",
+            "parkRideFacilityId": "12",
+            "parkRideName": "Mona Vale"
+          },
+          {
+            "stopId": "210115",
+            "parkRideFacilityId": "11",
+            "parkRideName": "Narrabeen"
+          },
+          {
+            "stopId": "275075",
+            "parkRideFacilityId": "21",
+            "parkRideName": "Penrith (at-grade)"
+          },
+          {
+            "stopId": "275010",
+            "parkRideFacilityId": "21",
+            "parkRideName": "Penrith (at-grade)"
+          },
+          {
+            "stopId": "275075",
+            "parkRideFacilityId": "22",
+            "parkRideName": "Penrith (multi-level)"
+          },
+          {
+            "stopId": "275010",
+            "parkRideFacilityId": "22",
+            "parkRideName": "Penrith (multi-level)"
+          },
+          {
+            "stopId": "221210",
+            "parkRideFacilityId": "9",
+            "parkRideName": "Revesby"
+          },
+          {
+            "stopId": "221010",
+            "parkRideFacilityId": "37",
+            "parkRideName": "Riverwood"
+          },
+          {
+            "stopId": "2762106",
+            "parkRideFacilityId": "24",
+            "parkRideName": "Schofields"
+          },
+          {
+            "stopId": "276220",
+            "parkRideFacilityId": "24",
+            "parkRideName": "Schofields"
+          },
+          {
+            "stopId": "214732",
+            "parkRideFacilityId": "488",
+            "parkRideName": "Seven Hills"
+          },
+          {
+            "stopId": "214710",
+            "parkRideFacilityId": "488",
+            "parkRideName": "Seven Hills"
+          },
+          {
+            "stopId": "276010",
+            "parkRideFacilityId": "18",
+            "parkRideName": "St Marys"
+          },
+          {
+            "stopId": "223210",
+            "parkRideFacilityId": "15",
+            "parkRideName": "Sutherland"
+          },
+          {
+            "stopId": "2232126",
+            "parkRideFacilityId": "15",
+            "parkRideName": "Sutherland"
+          },
+          {
+            "stopId": "2232254",
+            "parkRideFacilityId": "15",
+            "parkRideName": "Sutherland"
+          },
+          {
+            "stopId": "2155384",
+            "parkRideFacilityId": "26",
+            "parkRideName": "Tallawong P1"
+          },
+          {
+            "stopId": "2155384",
+            "parkRideFacilityId": "27",
+            "parkRideName": "Tallawong P2"
+          },
+          {
+            "stopId": "2155384",
+            "parkRideFacilityId": "28",
+            "parkRideName": "Tallawong P3"
+          },
+          {
+            "stopId": "210120",
+            "parkRideFacilityId": "10",
+            "parkRideName": "Warriewood"
+          },
+          {
+            "stopId": "217010",
+            "parkRideFacilityId": "23",
+            "parkRideName": "Warwick Farm"
+          },
+          {
+            "stopId": "211420",
+            "parkRideFacilityId": "14",
+            "parkRideName": "West Ryde"
           }
         ]
       }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -610,142 +610,142 @@ components:
       example:
         - stopId: "213110"
           parkRideFacilityId: "486"
-          parkRideName: Park&Ride - Ashfield
+          parkRideName: Ashfield
         - stopId: "2153478"
           parkRideFacilityId: "31"
-          parkRideName: Park&Ride - Bella Vista
+          parkRideName: Bella Vista
         - stopId: "220910"
           parkRideFacilityId: "35"
-          parkRideName: Park&Ride - Beverly Hills
+          parkRideName: Beverly Hills
         - stopId: "210017"
           parkRideFacilityId: "490"
-          parkRideName: Park&Ride - Brookvale
+          parkRideName: Brookvale
         - stopId: "256020"
           parkRideFacilityId: "19"
-          parkRideName: Park&Ride - Campbelltown Farrow Rd (north)
+          parkRideName: Campbelltown Farrow Rd (north)
         - stopId: "256020"
           parkRideFacilityId: "20"
-          parkRideName: Park&Ride - Campbelltown Hurley St
+          parkRideName: Campbelltown Hurley St
         - stopId: "2126158"
           parkRideFacilityId: "33"
-          parkRideName: Park&Ride - Cherrybrook
+          parkRideName: Cherrybrook
         - stopId: "209913"
           parkRideFacilityId: "13"
-          parkRideName: Park&Ride - Dee Why
+          parkRideName: Dee Why
         - stopId: "217426"
           parkRideFacilityId: "17"
-          parkRideName: Park&Ride - Edmondson Park (south)
+          parkRideName: Edmondson Park (south)
         - stopId: "275020"
           parkRideFacilityId: "36"
-          parkRideName: Park&Ride - Emu Plains
+          parkRideName: Emu Plains
         - stopId: "207210"
           parkRideFacilityId: "6"
-          parkRideName: Park&Ride - Gordon Henry St (north)
+          parkRideName: Gordon Henry St (north)
         - stopId: "225041"
           parkRideFacilityId: "8"
-          parkRideName: Park&Ride - Gosford
+          parkRideName: Gosford
         - stopId: "225040"
           parkRideFacilityId: "8"
-          parkRideName: Park&Ride - Gosford
+          parkRideName: Gosford
         - stopId: "2154392"
           parkRideFacilityId: "32"
-          parkRideName: Park&Ride - Hills Showground
+          parkRideName: Hills Showground
         - stopId: "207720"
           parkRideFacilityId: "25"
-          parkRideName: Park&Ride - Hornsby
+          parkRideName: Hornsby
         - stopId: "207763"
           parkRideFacilityId: "25"
-          parkRideName: Park&Ride - Hornsby
+          parkRideName: Hornsby
         - stopId: "2155382"
           parkRideFacilityId: "29"
-          parkRideName: Park&Ride - Kellyville (north)
+          parkRideName: Kellyville (north)
         - stopId: "2155382"
           parkRideFacilityId: "30"
-          parkRideName: Park&Ride - Kellyville (south)
+          parkRideName: Kellyville (south)
         - stopId: "253330"
           parkRideFacilityId: "7"
-          parkRideName: Park&Ride - Kiama
+          parkRideName: Kiama
         - stopId: "221710"
           parkRideFacilityId: "487"
-          parkRideName: Park&Ride - Kogarah
+          parkRideName: Kogarah
         - stopId: "217933"
           parkRideFacilityId: "16"
-          parkRideName: Park&Ride - Leppington
+          parkRideName: Leppington
         - stopId: "207010"
           parkRideFacilityId: "34"
-          parkRideName: Park&Ride - Lindfield Village Green
+          parkRideName: Lindfield Village Green
         - stopId: "209325"
           parkRideFacilityId: "489"
-          parkRideName: Park&Ride - Manly Vale
+          parkRideName: Manly Vale
         - stopId: "209324"
           parkRideFacilityId: "489"
-          parkRideName: Park&Ride - Manly Vale
+          parkRideName: Manly Vale
         - stopId: "2103108"
           parkRideFacilityId: "12"
-          parkRideName: Park&Ride - Mona Vale
+          parkRideName: Mona Vale
         - stopId: "210318"
           parkRideFacilityId: "12"
-          parkRideName: Park&Ride - Mona Vale
+          parkRideName: Mona Vale
         - stopId: "210115"
           parkRideFacilityId: "11"
-          parkRideName: Park&Ride - Narrabeen
+          parkRideName: Narrabeen
         - stopId: "275075"
           parkRideFacilityId: "21"
-          parkRideName: Park&Ride - Penrith (at-grade)
+          parkRideName: Penrith (at-grade)
         - stopId: "275010"
           parkRideFacilityId: "21"
-          parkRideName: Park&Ride - Penrith (at-grade)
+          parkRideName: Penrith (at-grade)
         - stopId: "275075"
           parkRideFacilityId: "22"
-          parkRideName: Park&Ride - Penrith (multi-level)
+          parkRideName: Penrith (multi-level)
         - stopId: "275010"
           parkRideFacilityId: "22"
-          parkRideName: Park&Ride - Penrith (multi-level)
+          parkRideName: Penrith (multi-level)
         - stopId: "221210"
           parkRideFacilityId: "9"
-          parkRideName: Park&Ride - Revesby
+          parkRideName: Revesby
         - stopId: "221010"
           parkRideFacilityId: "37"
-          parkRideName: Park&Ride - Riverwood
+          parkRideName: Riverwood
         - stopId: "2762106"
           parkRideFacilityId: "24"
-          parkRideName: Park&Ride - Schofields
+          parkRideName: Schofields
         - stopId: "276220"
           parkRideFacilityId: "24"
-          parkRideName: Park&Ride - Schofields
+          parkRideName: Schofields
         - stopId: "214732"
           parkRideFacilityId: "488"
-          parkRideName: Park&Ride - Seven Hills
+          parkRideName: Seven Hills
         - stopId: "214710"
           parkRideFacilityId: "488"
-          parkRideName: Park&Ride - Seven Hills
+          parkRideName: Seven Hills
         - stopId: "276010"
           parkRideFacilityId: "18"
-          parkRideName: Park&Ride - St Marys
+          parkRideName: St Marys
         - stopId: "223210"
           parkRideFacilityId: "15"
-          parkRideName: Park&Ride - Sutherland
+          parkRideName: Sutherland
         - stopId: "2232126"
           parkRideFacilityId: "15"
-          parkRideName: Park&Ride - Sutherland
+          parkRideName: Sutherland
         - stopId: "2232254"
           parkRideFacilityId: "15"
-          parkRideName: Park&Ride - Sutherland
+          parkRideName: Sutherland
         - stopId: "2155384"
           parkRideFacilityId: "26"
-          parkRideName: Park&Ride - Tallawong P1
+          parkRideName: Tallawong P1
         - stopId: "2155384"
           parkRideFacilityId: "27"
-          parkRideName: Park&Ride - Tallawong P2
+          parkRideName: Tallawong P2
         - stopId: "2155384"
           parkRideFacilityId: "28"
-          parkRideName: Park&Ride - Tallawong P3
+          parkRideName: Tallawong P3
         - stopId: "210120"
           parkRideFacilityId: "10"
-          parkRideName: Park&Ride - Warriewood
+          parkRideName: Warriewood
         - stopId: "217010"
           parkRideFacilityId: "23"
-          parkRideName: Park&Ride - Warwick Farm
+          parkRideName: Warwick Farm
         - stopId: "211420"
           parkRideFacilityId: "14"
-          parkRideName: Park&Ride - West Ryde
+          parkRideName: West Ryde

--- a/openapi.json
+++ b/openapi.json
@@ -870,237 +870,237 @@
           {
             "stopId": "213110",
             "parkRideFacilityId": "486",
-            "parkRideName": "Park&Ride - Ashfield"
+            "parkRideName": "Ashfield"
           },
           {
             "stopId": "2153478",
             "parkRideFacilityId": "31",
-            "parkRideName": "Park&Ride - Bella Vista"
+            "parkRideName": "Bella Vista"
           },
           {
             "stopId": "220910",
             "parkRideFacilityId": "35",
-            "parkRideName": "Park&Ride - Beverly Hills"
+            "parkRideName": "Beverly Hills"
           },
           {
             "stopId": "210017",
             "parkRideFacilityId": "490",
-            "parkRideName": "Park&Ride - Brookvale"
+            "parkRideName": "Brookvale"
           },
           {
             "stopId": "256020",
             "parkRideFacilityId": "19",
-            "parkRideName": "Park&Ride - Campbelltown Farrow Rd (north)"
+            "parkRideName": "Campbelltown Farrow Rd (north)"
           },
           {
             "stopId": "256020",
             "parkRideFacilityId": "20",
-            "parkRideName": "Park&Ride - Campbelltown Hurley St"
+            "parkRideName": "Campbelltown Hurley St"
           },
           {
             "stopId": "2126158",
             "parkRideFacilityId": "33",
-            "parkRideName": "Park&Ride - Cherrybrook"
+            "parkRideName": "Cherrybrook"
           },
           {
             "stopId": "209913",
             "parkRideFacilityId": "13",
-            "parkRideName": "Park&Ride - Dee Why"
+            "parkRideName": "Dee Why"
           },
           {
             "stopId": "217426",
             "parkRideFacilityId": "17",
-            "parkRideName": "Park&Ride - Edmondson Park (south)"
+            "parkRideName": "Edmondson Park (south)"
           },
           {
             "stopId": "275020",
             "parkRideFacilityId": "36",
-            "parkRideName": "Park&Ride - Emu Plains"
+            "parkRideName": "Emu Plains"
           },
           {
             "stopId": "207210",
             "parkRideFacilityId": "6",
-            "parkRideName": "Park&Ride - Gordon Henry St (north)"
+            "parkRideName": "Gordon Henry St (north)"
           },
           {
             "stopId": "225041",
             "parkRideFacilityId": "8",
-            "parkRideName": "Park&Ride - Gosford"
+            "parkRideName": "Gosford"
           },
           {
             "stopId": "225040",
             "parkRideFacilityId": "8",
-            "parkRideName": "Park&Ride - Gosford"
+            "parkRideName": "Gosford"
           },
           {
             "stopId": "2154392",
             "parkRideFacilityId": "32",
-            "parkRideName": "Park&Ride - Hills Showground"
+            "parkRideName": "Hills Showground"
           },
           {
             "stopId": "207720",
             "parkRideFacilityId": "25",
-            "parkRideName": "Park&Ride - Hornsby"
+            "parkRideName": "Hornsby"
           },
           {
             "stopId": "207763",
             "parkRideFacilityId": "25",
-            "parkRideName": "Park&Ride - Hornsby"
+            "parkRideName": "Hornsby"
           },
           {
             "stopId": "2155382",
             "parkRideFacilityId": "29",
-            "parkRideName": "Park&Ride - Kellyville (north)"
+            "parkRideName": "Kellyville (north)"
           },
           {
             "stopId": "2155382",
             "parkRideFacilityId": "30",
-            "parkRideName": "Park&Ride - Kellyville (south)"
+            "parkRideName": "Kellyville (south)"
           },
           {
             "stopId": "253330",
             "parkRideFacilityId": "7",
-            "parkRideName": "Park&Ride - Kiama"
+            "parkRideName": "Kiama"
           },
           {
             "stopId": "221710",
             "parkRideFacilityId": "487",
-            "parkRideName": "Park&Ride - Kogarah"
+            "parkRideName": "Kogarah"
           },
           {
             "stopId": "217933",
             "parkRideFacilityId": "16",
-            "parkRideName": "Park&Ride - Leppington"
+            "parkRideName": "Leppington"
           },
           {
             "stopId": "207010",
             "parkRideFacilityId": "34",
-            "parkRideName": "Park&Ride - Lindfield Village Green"
+            "parkRideName": "Lindfield Village Green"
           },
           {
             "stopId": "209325",
             "parkRideFacilityId": "489",
-            "parkRideName": "Park&Ride - Manly Vale"
+            "parkRideName": "Manly Vale"
           },
           {
             "stopId": "209324",
             "parkRideFacilityId": "489",
-            "parkRideName": "Park&Ride - Manly Vale"
+            "parkRideName": "Manly Vale"
           },
           {
             "stopId": "2103108",
             "parkRideFacilityId": "12",
-            "parkRideName": "Park&Ride - Mona Vale"
+            "parkRideName": "Mona Vale"
           },
           {
             "stopId": "210318",
             "parkRideFacilityId": "12",
-            "parkRideName": "Park&Ride - Mona Vale"
+            "parkRideName": "Mona Vale"
           },
           {
             "stopId": "210115",
             "parkRideFacilityId": "11",
-            "parkRideName": "Park&Ride - Narrabeen"
+            "parkRideName": "Narrabeen"
           },
           {
             "stopId": "275075",
             "parkRideFacilityId": "21",
-            "parkRideName": "Park&Ride - Penrith (at-grade)"
+            "parkRideName": "Penrith (at-grade)"
           },
           {
             "stopId": "275010",
             "parkRideFacilityId": "21",
-            "parkRideName": "Park&Ride - Penrith (at-grade)"
+            "parkRideName": "Penrith (at-grade)"
           },
           {
             "stopId": "275075",
             "parkRideFacilityId": "22",
-            "parkRideName": "Park&Ride - Penrith (multi-level)"
+            "parkRideName": "Penrith (multi-level)"
           },
           {
             "stopId": "275010",
             "parkRideFacilityId": "22",
-            "parkRideName": "Park&Ride - Penrith (multi-level)"
+            "parkRideName": "Penrith (multi-level)"
           },
           {
             "stopId": "221210",
             "parkRideFacilityId": "9",
-            "parkRideName": "Park&Ride - Revesby"
+            "parkRideName": "Revesby"
           },
           {
             "stopId": "221010",
             "parkRideFacilityId": "37",
-            "parkRideName": "Park&Ride - Riverwood"
+            "parkRideName": "Riverwood"
           },
           {
             "stopId": "2762106",
             "parkRideFacilityId": "24",
-            "parkRideName": "Park&Ride - Schofields"
+            "parkRideName": "Schofields"
           },
           {
             "stopId": "276220",
             "parkRideFacilityId": "24",
-            "parkRideName": "Park&Ride - Schofields"
+            "parkRideName": "Schofields"
           },
           {
             "stopId": "214732",
             "parkRideFacilityId": "488",
-            "parkRideName": "Park&Ride - Seven Hills"
+            "parkRideName": "Seven Hills"
           },
           {
             "stopId": "214710",
             "parkRideFacilityId": "488",
-            "parkRideName": "Park&Ride - Seven Hills"
+            "parkRideName": "Seven Hills"
           },
           {
             "stopId": "276010",
             "parkRideFacilityId": "18",
-            "parkRideName": "Park&Ride - St Marys"
+            "parkRideName": "St Marys"
           },
           {
             "stopId": "223210",
             "parkRideFacilityId": "15",
-            "parkRideName": "Park&Ride - Sutherland"
+            "parkRideName": "Sutherland"
           },
           {
             "stopId": "2232126",
             "parkRideFacilityId": "15",
-            "parkRideName": "Park&Ride - Sutherland"
+            "parkRideName": "Sutherland"
           },
           {
             "stopId": "2232254",
             "parkRideFacilityId": "15",
-            "parkRideName": "Park&Ride - Sutherland"
+            "parkRideName": "Sutherland"
           },
           {
             "stopId": "2155384",
             "parkRideFacilityId": "26",
-            "parkRideName": "Park&Ride - Tallawong P1"
+            "parkRideName": "Tallawong P1"
           },
           {
             "stopId": "2155384",
             "parkRideFacilityId": "27",
-            "parkRideName": "Park&Ride - Tallawong P2"
+            "parkRideName": "Tallawong P2"
           },
           {
             "stopId": "2155384",
             "parkRideFacilityId": "28",
-            "parkRideName": "Park&Ride - Tallawong P3"
+            "parkRideName": "Tallawong P3"
           },
           {
             "stopId": "210120",
             "parkRideFacilityId": "10",
-            "parkRideName": "Park&Ride - Warriewood"
+            "parkRideName": "Warriewood"
           },
           {
             "stopId": "217010",
             "parkRideFacilityId": "23",
-            "parkRideName": "Park&Ride - Warwick Farm"
+            "parkRideName": "Warwick Farm"
           },
           {
             "stopId": "211420",
             "parkRideFacilityId": "14",
-            "parkRideName": "Park&Ride - West Ryde"
+            "parkRideName": "West Ryde"
           }
         ]
       }

--- a/src/park_ride_facilities.json
+++ b/src/park_ride_facilities.json
@@ -2,236 +2,236 @@
   {
     "stopId": "213110",
     "parkRideFacilityId": "486",
-    "parkRideName": "Park&Ride - Ashfield"
+    "parkRideName": "Ashfield"
   },
   {
     "stopId": "2153478",
     "parkRideFacilityId": "31",
-    "parkRideName": "Park&Ride - Bella Vista"
+    "parkRideName": "Bella Vista"
   },
   {
     "stopId": "220910",
     "parkRideFacilityId": "35",
-    "parkRideName": "Park&Ride - Beverly Hills"
+    "parkRideName": "Beverly Hills"
   },
   {
     "stopId": "210017",
     "parkRideFacilityId": "490",
-    "parkRideName": "Park&Ride - Brookvale"
+    "parkRideName": "Brookvale"
   },
   {
     "stopId": "256020",
     "parkRideFacilityId": "19",
-    "parkRideName": "Park&Ride - Campbelltown Farrow Rd (north)"
+    "parkRideName": "Campbelltown Farrow Rd (north)"
   },
   {
     "stopId": "256020",
     "parkRideFacilityId": "20",
-    "parkRideName": "Park&Ride - Campbelltown Hurley St"
+    "parkRideName": "Campbelltown Hurley St"
   },
   {
     "stopId": "2126158",
     "parkRideFacilityId": "33",
-    "parkRideName": "Park&Ride - Cherrybrook"
+    "parkRideName": "Cherrybrook"
   },
   {
     "stopId": "209913",
     "parkRideFacilityId": "13",
-    "parkRideName": "Park&Ride - Dee Why"
+    "parkRideName": "Dee Why"
   },
   {
     "stopId": "217426",
     "parkRideFacilityId": "17",
-    "parkRideName": "Park&Ride - Edmondson Park (south)"
+    "parkRideName": "Edmondson Park (south)"
   },
   {
     "stopId": "275020",
     "parkRideFacilityId": "36",
-    "parkRideName": "Park&Ride - Emu Plains"
+    "parkRideName": "Emu Plains"
   },
   {
     "stopId": "207210",
     "parkRideFacilityId": "6",
-    "parkRideName": "Park&Ride - Gordon Henry St (north)"
+    "parkRideName": "Gordon Henry St (north)"
   },
   {
     "stopId": "225041",
     "parkRideFacilityId": "8",
-    "parkRideName": "Park&Ride - Gosford"
+    "parkRideName": "Gosford"
   },
   {
     "stopId": "225040",
     "parkRideFacilityId": "8",
-    "parkRideName": "Park&Ride - Gosford"
+    "parkRideName": "Gosford"
   },
   {
     "stopId": "2154392",
     "parkRideFacilityId": "32",
-    "parkRideName": "Park&Ride - Hills Showground"
+    "parkRideName": "Hills Showground"
   },
   {
     "stopId": "207720",
     "parkRideFacilityId": "25",
-    "parkRideName": "Park&Ride - Hornsby"
+    "parkRideName": "Hornsby"
   },
   {
     "stopId": "207763",
     "parkRideFacilityId": "25",
-    "parkRideName": "Park&Ride - Hornsby"
+    "parkRideName": "Hornsby"
   },
   {
     "stopId": "2155382",
     "parkRideFacilityId": "29",
-    "parkRideName": "Park&Ride - Kellyville (north)"
+    "parkRideName": "Kellyville (north)"
   },
   {
     "stopId": "2155382",
     "parkRideFacilityId": "30",
-    "parkRideName": "Park&Ride - Kellyville (south)"
+    "parkRideName": "Kellyville (south)"
   },
   {
     "stopId": "253330",
     "parkRideFacilityId": "7",
-    "parkRideName": "Park&Ride - Kiama"
+    "parkRideName": "Kiama"
   },
   {
     "stopId": "221710",
     "parkRideFacilityId": "487",
-    "parkRideName": "Park&Ride - Kogarah"
+    "parkRideName": "Kogarah"
   },
   {
     "stopId": "217933",
     "parkRideFacilityId": "16",
-    "parkRideName": "Park&Ride - Leppington"
+    "parkRideName": "Leppington"
   },
   {
     "stopId": "207010",
     "parkRideFacilityId": "34",
-    "parkRideName": "Park&Ride - Lindfield Village Green"
+    "parkRideName": "Lindfield Village Green"
   },
   {
     "stopId": "209325",
     "parkRideFacilityId": "489",
-    "parkRideName": "Park&Ride - Manly Vale"
+    "parkRideName": "Manly Vale"
   },
   {
     "stopId": "209324",
     "parkRideFacilityId": "489",
-    "parkRideName": "Park&Ride - Manly Vale"
+    "parkRideName": "Manly Vale"
   },
   {
     "stopId": "2103108",
     "parkRideFacilityId": "12",
-    "parkRideName": "Park&Ride - Mona Vale"
+    "parkRideName": "Mona Vale"
   },
   {
     "stopId": "210318",
     "parkRideFacilityId": "12",
-    "parkRideName": "Park&Ride - Mona Vale"
+    "parkRideName": "Mona Vale"
   },
   {
     "stopId": "210115",
     "parkRideFacilityId": "11",
-    "parkRideName": "Park&Ride - Narrabeen"
+    "parkRideName": "Narrabeen"
   },
   {
     "stopId": "275075",
     "parkRideFacilityId": "21",
-    "parkRideName": "Park&Ride - Penrith (at-grade)"
+    "parkRideName": "Penrith (at-grade)"
   },
   {
     "stopId": "275010",
     "parkRideFacilityId": "21",
-    "parkRideName": "Park&Ride - Penrith (at-grade)"
+    "parkRideName": "Penrith (at-grade)"
   },
   {
     "stopId": "275075",
     "parkRideFacilityId": "22",
-    "parkRideName": "Park&Ride - Penrith (multi-level)"
+    "parkRideName": "Penrith (multi-level)"
   },
   {
     "stopId": "275010",
     "parkRideFacilityId": "22",
-    "parkRideName": "Park&Ride - Penrith (multi-level)"
+    "parkRideName": "Penrith (multi-level)"
   },
   {
     "stopId": "221210",
     "parkRideFacilityId": "9",
-    "parkRideName": "Park&Ride - Revesby"
+    "parkRideName": "Revesby"
   },
   {
     "stopId": "221010",
     "parkRideFacilityId": "37",
-    "parkRideName": "Park&Ride - Riverwood"
+    "parkRideName": "Riverwood"
   },
   {
     "stopId": "2762106",
     "parkRideFacilityId": "24",
-    "parkRideName": "Park&Ride - Schofields"
+    "parkRideName": "Schofields"
   },
   {
     "stopId": "276220",
     "parkRideFacilityId": "24",
-    "parkRideName": "Park&Ride - Schofields"
+    "parkRideName": "Schofields"
   },
   {
     "stopId": "214732",
     "parkRideFacilityId": "488",
-    "parkRideName": "Park&Ride - Seven Hills"
+    "parkRideName": "Seven Hills"
   },
   {
     "stopId": "214710",
     "parkRideFacilityId": "488",
-    "parkRideName": "Park&Ride - Seven Hills"
+    "parkRideName": "Seven Hills"
   },
   {
     "stopId": "276010",
     "parkRideFacilityId": "18",
-    "parkRideName": "Park&Ride - St Marys"
+    "parkRideName": "St Marys"
   },
   {
     "stopId": "223210",
     "parkRideFacilityId": "15",
-    "parkRideName": "Park&Ride - Sutherland"
+    "parkRideName": "Sutherland"
   },
   {
     "stopId": "2232126",
     "parkRideFacilityId": "15",
-    "parkRideName": "Park&Ride - Sutherland"
+    "parkRideName": "Sutherland"
   },
   {
     "stopId": "2232254",
     "parkRideFacilityId": "15",
-    "parkRideName": "Park&Ride - Sutherland"
+    "parkRideName": "Sutherland"
   },
   {
     "stopId": "2155384",
     "parkRideFacilityId": "26",
-    "parkRideName": "Park&Ride - Tallawong P1"
+    "parkRideName": "Tallawong P1"
   },
   {
     "stopId": "2155384",
     "parkRideFacilityId": "27",
-    "parkRideName": "Park&Ride - Tallawong P2"
+    "parkRideName": "Tallawong P2"
   },
   {
     "stopId": "2155384",
     "parkRideFacilityId": "28",
-    "parkRideName": "Park&Ride - Tallawong P3"
+    "parkRideName": "Tallawong P3"
   },
   {
     "stopId": "210120",
     "parkRideFacilityId": "10",
-    "parkRideName": "Park&Ride - Warriewood"
+    "parkRideName": "Warriewood"
   },
   {
     "stopId": "217010",
     "parkRideFacilityId": "23",
-    "parkRideName": "Park&Ride - Warwick Farm"
+    "parkRideName": "Warwick Farm"
   },
   {
     "stopId": "211420",
     "parkRideFacilityId": "14",
-    "parkRideName": "Park&Ride - West Ryde"
+    "parkRideName": "West Ryde"
   }
 ]


### PR DESCRIPTION
# Add special dates and simplify Park & Ride facility names

This PR makes two key changes:

1. Adds numerous special dates to the API including:
   - New Year's Eve, ANZAC Day, Halloween
   - Valentine's Day and Valentine's week celebrations
   - International days (Women's, Men's, Peace, Accessibility)
   - Cultural events (Chinese New Year, Holi, NAIDOC Week)
   - Pop culture days (Star Wars, Mario, Harry Potter, Taylor Swift)
   - Australian events (Australia Day, Vivid Sydney, Melbourne Cup)

2. Simplifies Park & Ride facility names by removing the "Park&Ride - " prefix from all entries, making them more concise while maintaining location information.