### PR TITLE
Add whats_on_sydney schema and improve README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,29 +14,31 @@ https://ksharma-xyz.github.io/KRAIL-CONFIG/
 After adding a new JSON file to the `src/` folder (e.g., `src/park_ride_facilities.json`), follow these steps:
 
 1. Generate the corresponding schema file
+   ```bash
+   node scripts/generate-schema.cjs
+   ```
 
-```bash
-node scripts/generate-schema.cjs
-```
-
-Why: This script automatically creates a .schema.json file from your JSON data file. It analyzes the structure and data
-types to generate proper validation rules.
+   Why: This script automatically creates a .schema.json file from your JSON data file. It analyzes the structure and
+   data
+   types to generate proper validation rules.
 
 2. Generate the OpenAPI specification
 
-`node scripts/generate-openapi.cjs`
+   `node scripts/generate-openapi.cjs`
 
-Why: This converts all JSON schemas in src/ into a unified OpenAPI 3.0 specification. It creates both docs/openapi.yaml
-and docs/openapi.json files that define your API endpoints and data structures.
+   Why: This converts all JSON schemas in src/ into a unified OpenAPI 3.0 specification. It creates both
+   docs/openapi.yaml
+   and docs/openapi.json files that define your API endpoints and data structures.
 
 3. Validate the generated specification
 
-`redocly lint docs/openapi.yaml`
+   `redocly lint docs/openapi.yaml`
 
-Why: This checks for any syntax errors, missing required fields, or OpenAPI specification violations. It ensures your
-documentation will render correctly and follows best practices.
+   Why: This checks for any syntax errors, missing required fields, or OpenAPI specification violations. It ensures your
+   documentation will render correctly and follows best practices.
 
 4. Build the documentation (optional for local preview)
+
    Why: Generates static HTML documentation files using Redoc. This step is optional locally since GitHub Actions will
    do this automatically when you push.
 
@@ -52,6 +54,7 @@ Why: Pushes your changes to trigger the GitHub Actions workflow, which will auto
 GitHub Pages.
 
 ### What happens automatically
+
 The GitHub Actions workflow (.github/workflows/schema-docs.yml) will:
 
 - Detect changes to JSON or schema files
@@ -64,11 +67,11 @@ The GitHub Actions workflow (.github/workflows/schema-docs.yml) will:
 ## Quick Setup
 
 ### Prerequisites
+
 - Node.js (v16+) and npm
 - Git
 
 ### Installation
-
 
 ### Prerequisites
 
@@ -85,7 +88,6 @@ npm install
 ```bash
 npm install -g @redocly/cli
 ```
-
 
 ### Repository Structure
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -94,6 +94,32 @@
         }
       }
     },
+    "/whats_on_sydney": {
+      "get": {
+        "summary": "Get whats_on_sydney schema",
+        "description": "Retrieve the whats_on_sydney schema with structure and examples",
+        "operationId": "getWhats_on_sydney",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved whats_on_sydney schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/whats_on_sydney"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Schema not found"
+          }
+        }
+      }
+    },
     "/schemas": {
       "get": {
         "summary": "List all schemas",
@@ -116,6 +142,9 @@
                     },
                     "park_ride_facilities": {
                       "$ref": "#/components/schemas/park_ride_facilities"
+                    },
+                    "whats_on_sydney": {
+                      "$ref": "#/components/schemas/whats_on_sydney"
                     }
                   }
                 }
@@ -1101,6 +1130,555 @@
             "stopId": "211420",
             "parkRideFacilityId": "14",
             "parkRideName": "West Ryde"
+          }
+        ]
+      },
+      "whats_on_sydney": {
+        "type": "object",
+        "title": "Whats_on_sydney",
+        "description": "Schema for whats_on_sydney",
+        "properties": {
+          "0": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "label",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          "1": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          "2": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          "3": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "socialPartnerName": {
+                      "type": "string"
+                    },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "socialPartnerName",
+                    "links"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type",
+              "buttons"
+            ],
+            "additionalProperties": false
+          },
+          "4": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "shareUrl": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "shareUrl"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type",
+              "buttons"
+            ],
+            "additionalProperties": false
+          },
+          "5": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "label",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type",
+              "buttons"
+            ],
+            "additionalProperties": false
+          },
+          "6": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "label",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type",
+              "buttons"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "0",
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6"
+        ],
+        "additionalProperties": false,
+        "example": [
+          {
+            "title": "Cta only card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": "2025-12-20",
+            "endDate": "2025-12-31",
+            "disclaimer": null,
+            "imageList": [
+              "https://images.unsplash.com/photo-1749751234397-41ee8a7887c2"
+            ],
+            "type": "Travel",
+            "buttons": [
+              {
+                "buttonType": "Cta",
+                "label": "Click Me",
+                "url": "https://example.com/cta"
+              }
+            ]
+          },
+          {
+            "title": "No Buttons Card Title",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": "Image Credit: Unsplash",
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1752367225760-34f565f0720f"
+            ],
+            "type": "Events",
+            "buttons": []
+          },
+          {
+            "title": "App Social Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"
+            ],
+            "type": "Travel",
+            "buttons": [
+              {
+                "buttonType": "AppSocial"
+              }
+            ]
+          },
+          {
+            "title": "Partner Social Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"
+            ],
+            "type": "Events",
+            "buttons": [
+              {
+                "buttonType": "PartnerSocial",
+                "socialPartnerName": "XYZ Place",
+                "links": [
+                  {
+                    "type": "Facebook",
+                    "url": "https://example.com"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "title": "Share Only Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1751906599846-2e31345c8014"
+            ],
+            "type": "Kids",
+            "buttons": [
+              {
+                "buttonType": "Share",
+                "shareUrl": "https://example.com/share"
+              }
+            ]
+          },
+          {
+            "title": "Cta + Share Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://images.unsplash.com/photo-1752939124510-e444139e6404"
+            ],
+            "type": "Sports",
+            "buttons": [
+              {
+                "buttonType": "Cta",
+                "label": "Click Me",
+                "url": "https://example.com/cta"
+              },
+              {
+                "buttonType": "Share",
+                "shareUrl": "https://example.com/share"
+              }
+            ]
+          },
+          {
+            "title": "Feedback Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1752832756659-4dd7c40f5ae7"
+            ],
+            "type": "Events",
+            "buttons": [
+              {
+                "buttonType": "Feedback",
+                "label": "Feedback",
+                "url": "https://example.com/feedback"
+              }
+            ]
           }
         ]
       }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -62,6 +62,23 @@ paths:
           description: Bad Request
         "404":
           description: Schema not found
+  /whats_on_sydney:
+    get:
+      summary: Get whats_on_sydney schema
+      description: Retrieve the whats_on_sydney schema with structure and examples
+      operationId: getWhats_on_sydney
+      security: []
+      responses:
+        "200":
+          description: Successfully retrieved whats_on_sydney schema
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/whats_on_sydney"
+        "400":
+          description: Bad Request
+        "404":
+          description: Schema not found
   /schemas:
     get:
       summary: List all schemas
@@ -82,6 +99,8 @@ paths:
                     $ref: "#/components/schemas/notice"
                   park_ride_facilities:
                     $ref: "#/components/schemas/park_ride_facilities"
+                  whats_on_sydney:
+                    $ref: "#/components/schemas/whats_on_sydney"
         "400":
           description: Bad Request
 components:
@@ -749,3 +768,388 @@ components:
         - stopId: "211420"
           parkRideFacilityId: "14"
           parkRideName: West Ryde
+    whats_on_sydney:
+      type: object
+      title: Whats_on_sydney
+      description: Schema for whats_on_sydney
+      properties:
+        "0":
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            disclaimer:
+              type: string
+            imageList:
+              type: array
+              items:
+                type: string
+            type:
+              type: string
+            buttons:
+              type: array
+              items:
+                type: object
+                properties:
+                  buttonType:
+                    type: string
+                  label:
+                    type: string
+                  url:
+                    type: string
+                required:
+                  - buttonType
+                  - label
+                  - url
+                additionalProperties: false
+          required:
+            - title
+            - description
+            - imageList
+            - type
+          additionalProperties: false
+        "1":
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            disclaimer:
+              type: string
+            imageList:
+              type: array
+              items:
+                type: string
+            type:
+              type: string
+            buttons:
+              type: array
+              items:
+                type: string
+          required:
+            - title
+            - description
+            - imageList
+            - type
+          additionalProperties: false
+        "2":
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            disclaimer:
+              type: string
+            imageList:
+              type: array
+              items:
+                type: string
+            type:
+              type: string
+            buttons:
+              type: array
+              items:
+                type: object
+                properties:
+                  buttonType:
+                    type: string
+                required:
+                  - buttonType
+                additionalProperties: false
+          required:
+            - title
+            - description
+            - imageList
+            - type
+          additionalProperties: false
+        "3":
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            disclaimer:
+              type: string
+            imageList:
+              type: array
+              items:
+                type: string
+            type:
+              type: string
+            buttons:
+              type: array
+              items:
+                type: object
+                properties:
+                  buttonType:
+                    type: string
+                  socialPartnerName:
+                    type: string
+                  links:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        url:
+                          type: string
+                      required:
+                        - type
+                        - url
+                      additionalProperties: false
+                required:
+                  - buttonType
+                  - socialPartnerName
+                  - links
+                additionalProperties: false
+          required:
+            - title
+            - description
+            - imageList
+            - type
+            - buttons
+          additionalProperties: false
+        "4":
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            disclaimer:
+              type: string
+            imageList:
+              type: array
+              items:
+                type: string
+            type:
+              type: string
+            buttons:
+              type: array
+              items:
+                type: object
+                properties:
+                  buttonType:
+                    type: string
+                  shareUrl:
+                    type: string
+                required:
+                  - buttonType
+                  - shareUrl
+                additionalProperties: false
+          required:
+            - title
+            - description
+            - imageList
+            - type
+            - buttons
+          additionalProperties: false
+        "5":
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            disclaimer:
+              type: string
+            imageList:
+              type: array
+              items:
+                type: string
+            type:
+              type: string
+            buttons:
+              type: array
+              items:
+                type: object
+                properties:
+                  buttonType:
+                    type: string
+                  label:
+                    type: string
+                  url:
+                    type: string
+                required:
+                  - buttonType
+                  - label
+                  - url
+                additionalProperties: false
+          required:
+            - title
+            - description
+            - imageList
+            - type
+            - buttons
+          additionalProperties: false
+        "6":
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            startDate:
+              type: string
+            endDate:
+              type: string
+            disclaimer:
+              type: string
+            imageList:
+              type: array
+              items:
+                type: string
+            type:
+              type: string
+            buttons:
+              type: array
+              items:
+                type: object
+                properties:
+                  buttonType:
+                    type: string
+                  label:
+                    type: string
+                  url:
+                    type: string
+                required:
+                  - buttonType
+                  - label
+                  - url
+                additionalProperties: false
+          required:
+            - title
+            - description
+            - imageList
+            - type
+            - buttons
+          additionalProperties: false
+      required:
+        - "0"
+        - "1"
+        - "2"
+        - "3"
+        - "4"
+        - "5"
+        - "6"
+      additionalProperties: false
+      example:
+        - title: Cta only card
+          description: This is a sample description for the Discover Card. It can be used
+            to display additional information.
+          startDate: 2025-12-20
+          endDate: 2025-12-31
+          disclaimer: null
+          imageList:
+            - https://images.unsplash.com/photo-1749751234397-41ee8a7887c2
+          type: Travel
+          buttons:
+            - buttonType: Cta
+              label: Click Me
+              url: https://example.com/cta
+        - title: No Buttons Card Title
+          description: This is a sample description for the Discover Card. It can be used
+            to display additional information.
+          startDate: null
+          endDate: null
+          disclaimer: "Image Credit: Unsplash"
+          imageList:
+            - https://plus.unsplash.com/premium_photo-1752367225760-34f565f0720f
+          type: Events
+          buttons: []
+        - title: App Social Card
+          description: This is a sample description for the Discover Card. It can be used
+            to display additional information.
+          startDate: null
+          endDate: null
+          disclaimer: null
+          imageList:
+            - https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b
+          type: Travel
+          buttons:
+            - buttonType: AppSocial
+        - title: Partner Social Card
+          description: This is a sample description for the Discover Card. It can be used
+            to display additional information.
+          startDate: null
+          endDate: null
+          disclaimer: null
+          imageList:
+            - https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b
+          type: Events
+          buttons:
+            - buttonType: PartnerSocial
+              socialPartnerName: XYZ Place
+              links:
+                - type: Facebook
+                  url: https://example.com
+        - title: Share Only Card
+          description: This is a sample description for the Discover Card. It can be used
+            to display additional information.
+          startDate: null
+          endDate: null
+          disclaimer: null
+          imageList:
+            - https://plus.unsplash.com/premium_photo-1751906599846-2e31345c8014
+          type: Kids
+          buttons:
+            - buttonType: Share
+              shareUrl: https://example.com/share
+        - title: Cta + Share Card
+          description: This is a sample description for the Discover Card. It can be used
+            to display additional information.
+          startDate: null
+          endDate: null
+          disclaimer: null
+          imageList:
+            - https://images.unsplash.com/photo-1752939124510-e444139e6404
+          type: Sports
+          buttons:
+            - buttonType: Cta
+              label: Click Me
+              url: https://example.com/cta
+            - buttonType: Share
+              shareUrl: https://example.com/share
+        - title: Feedback Card
+          description: This is a sample description for the Discover Card. It can be used
+            to display additional information.
+          startDate: null
+          endDate: null
+          disclaimer: null
+          imageList:
+            - https://plus.unsplash.com/premium_photo-1752832756659-4dd7c40f5ae7
+          type: Events
+          buttons:
+            - buttonType: Feedback
+              label: Feedback
+              url: https://example.com/feedback

--- a/openapi.json
+++ b/openapi.json
@@ -94,6 +94,32 @@
         }
       }
     },
+    "/whats_on_sydney": {
+      "get": {
+        "summary": "Get whats_on_sydney schema",
+        "description": "Retrieve the whats_on_sydney schema with structure and examples",
+        "operationId": "getWhats_on_sydney",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved whats_on_sydney schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/whats_on_sydney"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Schema not found"
+          }
+        }
+      }
+    },
     "/schemas": {
       "get": {
         "summary": "List all schemas",
@@ -116,6 +142,9 @@
                     },
                     "park_ride_facilities": {
                       "$ref": "#/components/schemas/park_ride_facilities"
+                    },
+                    "whats_on_sydney": {
+                      "$ref": "#/components/schemas/whats_on_sydney"
                     }
                   }
                 }
@@ -1101,6 +1130,555 @@
             "stopId": "211420",
             "parkRideFacilityId": "14",
             "parkRideName": "West Ryde"
+          }
+        ]
+      },
+      "whats_on_sydney": {
+        "type": "object",
+        "title": "Whats_on_sydney",
+        "description": "Schema for whats_on_sydney",
+        "properties": {
+          "0": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "label",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          "1": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          "2": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          "3": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "socialPartnerName": {
+                      "type": "string"
+                    },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "socialPartnerName",
+                    "links"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type",
+              "buttons"
+            ],
+            "additionalProperties": false
+          },
+          "4": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "shareUrl": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "shareUrl"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type",
+              "buttons"
+            ],
+            "additionalProperties": false
+          },
+          "5": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "label",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type",
+              "buttons"
+            ],
+            "additionalProperties": false
+          },
+          "6": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "endDate": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "imageList": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "type": {
+                "type": "string"
+              },
+              "buttons": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "buttonType",
+                    "label",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "imageList",
+              "type",
+              "buttons"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "0",
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6"
+        ],
+        "additionalProperties": false,
+        "example": [
+          {
+            "title": "Cta only card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": "2025-12-20",
+            "endDate": "2025-12-31",
+            "disclaimer": null,
+            "imageList": [
+              "https://images.unsplash.com/photo-1749751234397-41ee8a7887c2"
+            ],
+            "type": "Travel",
+            "buttons": [
+              {
+                "buttonType": "Cta",
+                "label": "Click Me",
+                "url": "https://example.com/cta"
+              }
+            ]
+          },
+          {
+            "title": "No Buttons Card Title",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": "Image Credit: Unsplash",
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1752367225760-34f565f0720f"
+            ],
+            "type": "Events",
+            "buttons": []
+          },
+          {
+            "title": "App Social Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"
+            ],
+            "type": "Travel",
+            "buttons": [
+              {
+                "buttonType": "AppSocial"
+              }
+            ]
+          },
+          {
+            "title": "Partner Social Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"
+            ],
+            "type": "Events",
+            "buttons": [
+              {
+                "buttonType": "PartnerSocial",
+                "socialPartnerName": "XYZ Place",
+                "links": [
+                  {
+                    "type": "Facebook",
+                    "url": "https://example.com"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "title": "Share Only Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1751906599846-2e31345c8014"
+            ],
+            "type": "Kids",
+            "buttons": [
+              {
+                "buttonType": "Share",
+                "shareUrl": "https://example.com/share"
+              }
+            ]
+          },
+          {
+            "title": "Cta + Share Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://images.unsplash.com/photo-1752939124510-e444139e6404"
+            ],
+            "type": "Sports",
+            "buttons": [
+              {
+                "buttonType": "Cta",
+                "label": "Click Me",
+                "url": "https://example.com/cta"
+              },
+              {
+                "buttonType": "Share",
+                "shareUrl": "https://example.com/share"
+              }
+            ]
+          },
+          {
+            "title": "Feedback Card",
+            "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+            "startDate": null,
+            "endDate": null,
+            "disclaimer": null,
+            "imageList": [
+              "https://plus.unsplash.com/premium_photo-1752832756659-4dd7c40f5ae7"
+            ],
+            "type": "Events",
+            "buttons": [
+              {
+                "buttonType": "Feedback",
+                "label": "Feedback",
+                "url": "https://example.com/feedback"
+              }
+            ]
           }
         ]
       }

--- a/src/whats_on_sydney.json
+++ b/src/whats_on_sydney.json
@@ -1,0 +1,114 @@
+[
+  {
+    "title": "Cta only card",
+    "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+    "startDate": "2025-12-20",
+    "endDate": "2025-12-31",
+    "disclaimer": null,
+    "imageList": ["https://images.unsplash.com/photo-1749751234397-41ee8a7887c2"],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Click Me",
+        "url": "https://example.com/cta"
+      }
+    ]
+  },
+  {
+    "title": "No Buttons Card Title",
+    "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+    "startDate": null,
+    "endDate": null,
+    "disclaimer": "Image Credit: Unsplash",
+    "imageList": ["https://plus.unsplash.com/premium_photo-1752367225760-34f565f0720f"],
+    "type": "Events",
+    "buttons": []
+  },
+  {
+    "title": "App Social Card",
+    "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+    "startDate": null,
+    "endDate": null,
+    "disclaimer": null,
+    "imageList": ["https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "AppSocial"
+      }
+    ]
+  },
+  {
+    "title": "Partner Social Card",
+    "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+    "startDate": null,
+    "endDate": null,
+    "disclaimer": null,
+    "imageList": ["https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "PartnerSocial",
+        "socialPartnerName": "XYZ Place",
+        "links": [
+          {
+            "type": "Facebook",
+            "url": "https://example.com"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "Share Only Card",
+    "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+    "startDate": null,
+    "endDate": null,
+    "disclaimer": null,
+    "imageList": ["https://plus.unsplash.com/premium_photo-1751906599846-2e31345c8014"],
+    "type": "Kids",
+    "buttons": [
+      {
+        "buttonType": "Share",
+        "shareUrl": "https://example.com/share"
+      }
+    ]
+  },
+  {
+    "title": "Cta + Share Card",
+    "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+    "startDate": null,
+    "endDate": null,
+    "disclaimer": null,
+    "imageList": ["https://images.unsplash.com/photo-1752939124510-e444139e6404"],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Click Me",
+        "url": "https://example.com/cta"
+      },
+      {
+        "buttonType": "Share",
+        "shareUrl": "https://example.com/share"
+      }
+    ]
+  },
+  {
+    "title": "Feedback Card",
+    "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
+    "startDate": null,
+    "endDate": null,
+    "disclaimer": null,
+    "imageList": ["https://plus.unsplash.com/premium_photo-1752832756659-4dd7c40f5ae7"],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Feedback",
+        "label": "Feedback",
+        "url": "https://example.com/feedback"
+      }
+    ]
+  }
+]

--- a/src/whats_on_sydney.schema.json
+++ b/src/whats_on_sydney.schema.json
@@ -1,0 +1,422 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Whats_on_sydney",
+  "description": "Schema for whats_on_sydney",
+  "properties": {
+    "0": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "disclaimer": {
+          "type": "string"
+        },
+        "imageList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "buttons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "buttonType": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "buttonType",
+              "label",
+              "url"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "title",
+        "description",
+        "imageList",
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "1": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "disclaimer": {
+          "type": "string"
+        },
+        "imageList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "buttons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "title",
+        "description",
+        "imageList",
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "2": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "disclaimer": {
+          "type": "string"
+        },
+        "imageList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "buttons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "buttonType": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "buttonType"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "title",
+        "description",
+        "imageList",
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "3": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "disclaimer": {
+          "type": "string"
+        },
+        "imageList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "buttons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "buttonType": {
+                "type": "string"
+              },
+              "socialPartnerName": {
+                "type": "string"
+              },
+              "links": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "buttonType",
+              "socialPartnerName",
+              "links"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "title",
+        "description",
+        "imageList",
+        "type",
+        "buttons"
+      ],
+      "additionalProperties": false
+    },
+    "4": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "disclaimer": {
+          "type": "string"
+        },
+        "imageList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "buttons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "buttonType": {
+                "type": "string"
+              },
+              "shareUrl": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "buttonType",
+              "shareUrl"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "title",
+        "description",
+        "imageList",
+        "type",
+        "buttons"
+      ],
+      "additionalProperties": false
+    },
+    "5": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "disclaimer": {
+          "type": "string"
+        },
+        "imageList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "buttons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "buttonType": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "buttonType",
+              "label",
+              "url"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "title",
+        "description",
+        "imageList",
+        "type",
+        "buttons"
+      ],
+      "additionalProperties": false
+    },
+    "6": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "disclaimer": {
+          "type": "string"
+        },
+        "imageList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "buttons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "buttonType": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "buttonType",
+              "label",
+              "url"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "title",
+        "description",
+        "imageList",
+        "type",
+        "buttons"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
### TL;DR

Added "What's On Sydney" schema to support event card display in the application.

### What changed?

- Added new `whats_on_sydney.json` data file with sample event cards
- Generated corresponding schema file (`whats_on_sydney.schema.json`)
- Updated OpenAPI specification to include the new schema
- Improved README formatting with proper code block indentation

### How to test?

1. Verify the schema validation works:
   ```bash
   node scripts/generate-schema.cjs
   ```

2. Check the OpenAPI documentation includes the new schema:
   ```bash
   node scripts/generate-openapi.cjs
   redocly lint docs/openapi.yaml
   ```

3. Verify the example data in the schema matches the expected format for different card types:
   - CTA only card
   - No buttons card
   - App social card
   - Partner social card
   - Share only card
   - CTA + Share card
   - Feedback card

### Why make this change?

This schema defines the structure for "What's On Sydney" event cards, supporting various card types with different button configurations. The schema enables validation of event data and provides documentation for frontend developers implementing the card display functionality.