### PR TITLE
Add Sydney attractions and events cards to discover_sydney.json

### DIFF
--- a/samples/discover_sydney.json
+++ b/samples/discover_sydney.json
@@ -1004,5 +1004,915 @@
         "buttonType": "Share"
       }
     ]
+  },
+  {
+    "cardId": "card_candlelight_taylor_swift",
+    "title": "Candlelight – Taylor Swift Tribute",
+    "description": "Experience Taylor Swift’s hits by string quartet in Sydney’s St Stephen’s Church under candlelight.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tickets",
+        "url": "https://feverup.com/m/149031"
+      }
+    ]
+  },
+  {
+    "cardId": "card_tall_ship_lunch_cruise",
+    "title": "Tall Ship Lunch Cruise – Sydney",
+    "description": "2-hour tall ship cruise with 3-course meal and Opera House & Harbour Bridge views.",
+    "imageList": [],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tickets",
+        "url": "https://feverup.com/m/111181"
+      }
+    ]
+  },
+  {
+    "cardId": "card_sydney_seaplane_scenic_flight",
+    "title": "Sydney Seaplane – Scenic Flight",
+    "description": "Take off from Rose Bay for panoramic Sydney views on a 30-minute seaplane adventure.",
+    "imageList": [],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Flight",
+        "url": "https://feverup.com/m/112924"
+      }
+    ]
+  },
+  {
+    "cardId": "card_taronga_zoo_sky_safari",
+    "title": "Taronga Zoo – Sky Safari Ride",
+    "description": "Ride Sydney’s only cable car with sweeping harbour views and spot wildlife below.",
+    "imageList": [],
+    "type": "Kids",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Plan Visit",
+        "url": "https://feverup.com/m/111183"
+      }
+    ]
+  },
+  {
+    "cardId": "card_sydney_tower_buffet",
+    "title": "Sydney Tower – Buffet Dining",
+    "description": "Enjoy 360° views of Sydney while dining at the revolving buffet restaurant.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Reserve Table",
+        "url": "https://feverup.com/m/111184"
+      }
+    ]
+  },
+  {
+    "cardId": "card_bubble_planet_immersive_experience",
+    "title": "Bubble Planet - Immersive Sydney",
+    "description": "Step into a magical world of bubbles with immersive light and sound at Paddington Pavilion.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tickets",
+        "url": "https://feverup.com/m/111181"
+      }
+    ]
+  },
+  {
+    "cardId": "card_oz_jet_boating",
+    "title": "Oz Jet Boating Adventure",
+    "description": "Feel the thrill on a high-speed jet boat tour of Sydney Harbour with stunning views.",
+    "imageList": [],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tour",
+        "url": "https://www.sydney.com/things-to-do/tours/oz-jet-boating"
+      }
+    ]
+  },
+  {
+    "cardId": "card_hyperkarting_sydney",
+    "title": "Hyperkarting & Virtual Reality",
+    "description": "Race electric karts and experience VR thrills in Moore Park, Sydney’s top adrenaline hub.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Site",
+        "url": "https://hyperkarting.com.au/"
+      }
+    ]
+  },
+  {
+    "cardId": "card_zero_latency_vr_parramatta",
+    "title": "Zero Latency VR - Parramatta",
+    "description": "Dive into multiplayer free-roam VR games in Parramatta with state-of-the-art tech.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Now",
+        "url": "https://zerolatencyvr.com/en/parramatta"
+      }
+    ]
+  },
+  {
+    "cardId": "card_vr_kingdom_chatswood",
+    "title": "VR Kingdom Chatswood",
+    "description": "Immersive VR experiences with multiple games and challenges in Chatswood.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Explore More",
+        "url": "https://vrkingdom.com.au/"
+      }
+    ]
+  },
+  {
+    "cardId": "card_virtual_room_sydney",
+    "title": "Virtual Room Sydney VR Escape",
+    "description": "Collaborate with friends in a multi-player VR escape game in Sydney’s city centre.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Escape",
+        "url": "https://sydney.virtual-room.com/"
+      }
+    ]
+  },
+  {
+    "cardId": "card_strike_bowling_darling_harbour",
+    "title": "Strike Bowling - Darling Harbour",
+    "description": "Enjoy bowling, arcade games, and great food right in the heart of Darling Harbour.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Reserve Lane",
+        "url": "https://strikebowling.com.au/locations/strike-darling-harbour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_zone_bowling_sydney",
+    "title": "Zone Bowling Sydney",
+    "description": "Classic bowling fun with vibrant atmosphere and dining options across Sydney locations.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.zonebowling.com/en-au/"
+      }
+    ]
+  },
+  {
+    "cardId": "card_yumcha_the_eight",
+    "title": "The Eight - Yum Cha Chinatown",
+    "description": "Authentic modern Chinese yum cha in Sydney’s Chinatown, perfect for sharing.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "See Menu",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-city/chinatown-and-haymarket/food-and-drink/the-eight-modern-chinese-restaurant"
+      }
+    ]
+  },
+  {
+    "cardId": "card_sea_life_sydney_aquarium",
+    "title": "Sea Life Sydney Aquarium",
+    "description": "Discover marine life from Australia and beyond at the iconic Darling Harbour aquarium.",
+    "imageList": [],
+    "type": "Kids",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Buy Tickets",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-city/darling-harbour/attractions/sea-life-sydney-aquarium"
+      }
+    ]
+  },
+  {
+    "cardId": "card_madame_tussauds_sydney",
+    "title": "Madame Tussauds Sydney",
+    "description": "Meet lifelike wax figures of celebrities and icons at Sydney’s famous wax museum.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Get Tickets",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-city/darling-harbour/attractions/madame-tussauds-sydney"
+      }
+    ]
+  },
+  {
+    "cardId": "card_archie_rose_distilling_co",
+    "title": "Archie Rose Distilling Co",
+    "description": "Create your own gin with distillery tours and tastings in Alexandria, Sydney.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Experience",
+        "url": "https://www.sydney.com/destinations/sydney/inner-sydney/alexandria-and-rosebery/food-and-drink/archie-rose-distilling-co"
+      }
+    ]
+  },
+  {
+    "cardId": "card_manly_spirits_distillery",
+    "title": "Manly Spirits Distillery",
+    "description": "Enjoy tastings and handcrafted spirits at Manly’s boutique distillery and bar.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-north/manly/food-and-drink/manly-spirits-co-distillery-and-tasting-bar"
+      }
+    ]
+  },
+  {
+    "cardId": "card_magic_mic_comedy_potts_point",
+    "title": "Magic Mic Comedy - Potts Point",
+    "description": "Laugh out loud at this popular open mic comedy night in Sydney’s vibrant Potts Point.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "More Info",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-city/potts-point-and-woolloomooloo/events/magic-mic-comedy"
+      }
+    ]
+  },
+  {
+    "cardId": "card_happy_endings_comedy_kings_cross",
+    "title": "Happy Endings Comedy Club",
+    "description": "Catch live stand-up and improv comedy shows at Kings Cross’ premier comedy venue.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tickets",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-city/potts-point-and-woolloomooloo/attractions/happy-endings-comedy-club-kings-cross"
+      }
+    ]
+  },
+  {
+    "cardId": "card_throw_axe_penrith",
+    "title": "Throw Axe Penrith",
+    "description": "Experience the thrill of axe throwing in Penrith with expert coaching in a safe environment.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Now",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/penrith/attractions/throw-axe"
+      }
+    ]
+  },
+  {
+    "cardId": "card_kiss_my_axe_alexandria",
+    "title": "Kiss My Axe - Alexandria",
+    "description": "Join axe throwing sessions in Alexandria, perfect for fun group activities and parties.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/inner-sydney/alexandria-and-rosebery/attractions/kiss-my-axe-alexandria"
+      }
+    ]
+  },
+  {
+    "cardId": "card_maniax_axe_throwing_marrickville",
+    "title": "Maniax Axe Throwing Sydney",
+    "description": "Indoor axe throwing in Marrickville offering a safe, fun and challenging experience.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "More Info",
+        "url": "https://www.sydney.com/destinations/sydney/inner-sydney/marrickville/attractions/maniax-axe-throwing-sydney-inner-west-0"
+      }
+    ]
+  },
+  {
+    "cardId": "card_blochaus_bouldering_marrickville",
+    "title": "Blochaus Bouldering Marrickville",
+    "description": "Indoor climbing gym with bouldering, training facilities, and community events in Marrickville.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/inner-sydney/marrickville/attractions/blochaus-bouldering-marrickville"
+      }
+    ]
+  },
+  {
+    "cardId": "card_mia_cucina_food_tours",
+    "title": "Mia Cucina Food Tours",
+    "description": "Discover Sydney’s best eats on guided food tours including coffee, Indian and Vietnamese options.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tour",
+        "url": "https://www.sydney.com/things-to-do/tours/mia-cucina-food-tours"
+      }
+    ]
+  },
+  {
+    "cardId": "card_mia_cucina_coffee_tour",
+    "title": "Mia Cucina Coffee Tour",
+    "description": "Explore Sydney’s vibrant coffee culture with tastings and café visits.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Coffee Tour",
+        "url": "https://www.sydney.com/things-to-do/tours/mia-cucina-food-tours/coffee-tour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_mia_cucina_indian_food_tour",
+    "title": "Mia Cucina Indian Food Tour",
+    "description": "Enjoy authentic Indian cuisine with tastings and cultural insights in Sydney.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Indian Food Tour",
+        "url": "https://www.sydney.com/things-to-do/tours/mia-cucina-food-tours/indian-food-tour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_mia_cucina_vietnamese_food_tour",
+    "title": "Mia Cucina Vietnamese Food Tour",
+    "description": "Taste Vietnamese delights with an expert guide around Sydney’s best Vietnamese eateries.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Vietnamese Tour",
+        "url": "https://www.sydney.com/things-to-do/tours/mia-cucina-food-tours/vietnamese-food-tour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_aboriginal_bush_tucker_tour",
+    "title": "Aboriginal Bush Tucker Tour",
+    "description": "Learn about native plants and traditional Aboriginal food practices in a guided tour.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Join Tour",
+        "url": "https://www.botanicgardens.org.au/whats-on/aboriginal-bush-tucker-tour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_manon_brasserie",
+    "title": "Manon Brasserie Sydney",
+    "description": "Chic brasserie in Sydney’s city centre offering modern Australian cuisine and drinks.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "View Menu",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-city/city-centre/food-and-drink/manon-brasserie"
+      }
+    ]
+  },
+  {
+    "cardId": "card_black_star_pastry_newtown",
+    "title": "Black Star Pastry Newtown",
+    "description": "Famous for its Instagrammable cakes and innovative pastries in Newtown.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/inner-sydney/newtown/food-and-drink/black-star-pastry-newtown"
+      }
+    ]
+  },
+  {
+    "cardId": "card_ifly_downunder_indoor_skydiving",
+    "title": "iFLY Downunder Indoor Skydiving",
+    "description": "Experience the thrill of skydiving safely indoors at Penrith’s premier venue.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Flight",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/penrith/attractions/ifly-downunder-sydney-west-indoor-skydiving"
+      }
+    ]
+  },
+  {
+    "cardId": "card_jet_ski_safaris_nsw",
+    "title": "Jet Ski Safaris NSW",
+    "description": "Guided jet ski tours on Sydney Harbour and coastal waters for an adrenaline rush.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Safari",
+        "url": "https://www.sydney.com/things-to-do/tours/jet-ski-safaris-nsw"
+      }
+    ]
+  },
+  {
+    "cardId": "card_diehard_indoor_paintball",
+    "title": "Diehard Indoor Paintball",
+    "description": "Indoor paintball battles in Sydney offering team games and corporate events.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Now",
+        "url": "https://www.diehardindoorpaintball.com.au/"
+      }
+    ]
+  },
+  {
+    "cardId": "card_treetops_adventure_western_sydney",
+    "title": "Treetops Adventure Western Sydney",
+    "description": "High ropes and zip lines course set in scenic natural bushland in Western Sydney.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Adventure",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/attractions/treetops-adventure-western-sydney"
+      }
+    ]
+  },
+  {
+    "cardId": "card_luddenham_raceway",
+    "title": "Luddenham Raceway",
+    "description": "Sydney’s premier motorsport venue hosting drag racing, events and driving experiences.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/penrith/attractions/luddenham-raceway-0"
+      }
+    ]
+  },
+  {
+    "cardId": "card_penrith_whitewater_stadium",
+    "title": "Penrith Whitewater Stadium",
+    "description": "Olympic-standard whitewater rafting and kayaking in Sydney’s beautiful Penrith area.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Adventure",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/penrith/attractions/penrith-whitewater-stadium"
+      }
+    ]
+  },
+  {
+    "cardId": "card_cables_wake_park",
+    "title": "Cables Wake Park",
+    "description": "Wakeboarding, waterskiing and stand-up paddleboarding in a scenic Penrith lake setting.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/penrith/attractions/cables-wake-park"
+      }
+    ]
+  },
+  {
+    "cardId": "card_jetpack_adventures_penrith",
+    "title": "Jetpack Adventures Penrith",
+    "description": "Try jetpacking — fly over the water and enjoy a unique aquatic thrill near Sydney.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Experience",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/penrith/attractions/jetpack-adventures-penrith"
+      }
+    ]
+  },
+  {
+    "cardId": "card_urbnsurf_sydney",
+    "title": "URBNSURF Sydney",
+    "description": "Indoor surfing wave pool offering consistent surf and lessons at Sydney Olympic Park.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/sydney-olympic-park/attractions/urbnsurf-sydney"
+      }
+    ]
+  },
+  {
+    "cardId": "card_southern_cross_gliding_club",
+    "title": "Southern Cross Gliding Club",
+    "description": "Enjoy serene gliding flights and training near Sydney for an unforgettable aerial experience.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Learn More",
+        "url": "https://www.sydney.com/things-to-do/tours/southern-cross-gliding-club"
+      }
+    ]
+  },
+  {
+    "cardId": "card_truninja_penrith",
+    "title": "Truninja Penrith",
+    "description": "Outdoor obstacle course combining fun and fitness in Penrith for all ages and skill levels.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Now",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/penrith/attractions/truninja-penrith"
+      }
+    ]
+  },
+  {
+    "cardId": "card_ninja_parc_south_granville",
+    "title": "Ninja Parc South Granville",
+    "description": "Indoor ninja warrior-style obstacle playground great for kids and adults alike.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/attractions/ninja-parc-south-granville"
+      }
+    ]
+  },
+  {
+    "cardId": "card_sydney_tower_eye",
+    "title": "Sydney Tower Eye",
+    "description": "Experience breathtaking 360° views from Sydney’s tallest tower in the city centre.",
+    "imageList": [],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Learn More",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-city/city-centre/attractions/sydney-tower-eye"
+      }
+    ]
+  },
+  {
+    "cardId": "card_luna_park_sydney",
+    "title": "Luna Park Sydney",
+    "description": "Iconic amusement park featuring rides, games, and the famous ferris wheel on Sydney Harbour.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-north/north-sydney-and-chatswood/attractions/luna-park-sydney"
+      }
+    ]
+  },
+  {
+    "cardId": "card_barrenjoey_lighthouse",
+    "title": "Barrenjoey Lighthouse Tour",
+    "description": "Guided tour to climb the historic 26-metre lighthouse with stunning Pacific Ocean views.",
+    "imageList": [],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tour",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-north/palm-beach/attractions/barrenjoey-lighthouse"
+      }
+    ]
+  },
+  {
+    "cardId": "card_vr_kingdom_chatswood",
+    "title": "VR Kingdom Chatswood",
+    "description": "Cutting-edge virtual reality gaming and immersive experiences in Sydney’s Chatswood area.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit VR Kingdom",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-north/north-sydney-and-chatswood/attractions/vr-kingdom-chatswood"
+      }
+    ]
+  },
+  {
+    "cardId": "card_metavurx_vr",
+    "title": "MetaVurx VR Sydney",
+    "description": "Immersive VR experiences with multiplayer games and advanced tech in Sydney.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit MetaVurx",
+        "url": "https://www.metavurxvr.com/"
+      }
+    ]
+  },
+  {
+    "cardId": "card_fortress_sydney_esports",
+    "title": "Fortress Sydney Esports",
+    "description": "Competitive esports venue and gaming hub located in Sydney’s Chippendale district.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Learn More",
+        "url": "https://www.sydney.com/destinations/sydney/inner-sydney/chippendale/attractions/fortress-sydney"
+      }
+    ]
+  },
+  {
+    "cardId": "card_timezone_games_arcade",
+    "title": "Timezone Games Arcade",
+    "description": "Classic and modern arcade games, family fun and entertainment centers in Sydney.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Timezone",
+        "url": "https://www.timezonegames.com/en-au/"
+      }
+    ]
+  },
+  {
+    "cardId": "card_archie_brothers_cirque_electriq_alexandria",
+    "title": "Archie Brothers Cirque Electriq Alexandria",
+    "description": "Immersive arcade and bar experience with retro games, laser tag, and circus-themed fun in Alexandria.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/inner-sydney/alexandria-and-rosebery/attractions/archie-brothers-cirque-electriq-alexandria"
+      }
+    ]
+  },
+  {
+    "cardId": "card_best_day_trips_from_sydney",
+    "title": "Best Day Trips from Sydney",
+    "description": "Explore top day trip ideas around Sydney including nature, history, and coastal adventures.",
+    "imageList": [],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Explore Trips",
+        "url": "https://www.sydney.com/articles/best-day-trips-from-sydney"
+      }
+    ]
+  },
+  {
+    "cardId": "card_black_star_pastry_newtown",
+    "title": "Black Star Pastry Newtown",
+    "description": "Famous for its iconic strawberry watermelon cake, a must-visit pastry spot in Newtown.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/inner-sydney/newtown/food-and-drink/black-star-pastry-newtown"
+      }
+    ]
+  },
+  {
+    "cardId": "card_ifly_downunder_sydney_west_indoor_skydiving",
+    "title": "iFLY Downunder Sydney West Indoor Skydiving",
+    "description": "Experience the thrill of skydiving indoors with safe vertical wind tunnels in Penrith.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Now",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/penrith/attractions/ifly-downunder-sydney-west-indoor-skydiving"
+      }
+    ]
+  },
+  {
+    "cardId": "card_oz_jet_boating",
+    "title": "Oz Jet Boating Sydney",
+    "description": "High-speed jet boat rides offering thrilling spins and scenic views on Sydney Harbour.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Ride",
+        "url": "https://www.sydney.com/things-to-do/tours/oz-jet-boating"
+      }
+    ]
+  },
+  {
+    "cardId": "card_jet_ski_safaris_nsw",
+    "title": "Jet Ski Safaris NSW",
+    "description": "Explore Sydney waterways on guided jet ski tours suitable for beginners and adventurers.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Learn More",
+        "url": "https://www.sydney.com/things-to-do/tours/jet-ski-safaris-nsw"
+      }
+    ]
+  },
+  {
+    "cardId": "card_diehard_indoor_paintball",
+    "title": "Diehard Indoor Paintball Sydney",
+    "description": "Action-packed indoor paintball battles in a safe and fun environment near Sydney CBD.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.diehardindoorpaintball.com.au/"
+      }
+    ]
+  },
+  {
+    "cardId": "card_treetops_adventure_western_sydney",
+    "title": "Treetops Adventure Western Sydney",
+    "description": "Outdoor treetop obstacle courses and zip lines for family fun and adrenaline in Western Sydney.",
+    "imageList": [],
+    "type": "Sports",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Now",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-west/attractions/treetops-adventure-western-sydney"
+      }
+    ]
+  },
+  {
+    "cardId": "card_mia_cucina_food_tours",
+    "title": "Mia Cucina Food Tours",
+    "description": "Guided food tours exploring Sydney’s diverse culinary scenes including coffee, Indian, and Vietnamese food.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Learn More",
+        "url": "https://www.sydney.com/things-to-do/tours/mia-cucina-food-tours"
+      }
+    ]
+  },
+  {
+    "cardId": "card_mia_cucina_coffee_tour",
+    "title": "Mia Cucina Coffee Tour",
+    "description": "Discover Sydney’s best cafes and specialty coffee spots on this curated coffee tour.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tour",
+        "url": "https://www.sydney.com/things-to-do/tours/mia-cucina-food-tours/coffee-tour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_mia_cucina_indian_food_tour",
+    "title": "Mia Cucina Indian Food Tour",
+    "description": "Taste authentic Indian cuisine and spices on this vibrant food tour in Sydney’s cultural hubs.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tour",
+        "url": "https://www.sydney.com/things-to-do/tours/mia-cucina-food-tours/indian-food-tour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_mia_cucina_vietnamese_food_tour",
+    "title": "Mia Cucina Vietnamese Food Tour",
+    "description": "Explore Sydney’s best Vietnamese restaurants and street food spots on this delicious tour.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Book Tour",
+        "url": "https://www.sydney.com/things-to-do/tours/mia-cucina-food-tours/vietnamese-food-tour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_aboriginal_bush_tucker_tour",
+    "title": "Aboriginal Bush Tucker Tour",
+    "description": "Discover native plants, traditional foods, and Aboriginal culture on this interactive bush tucker tour.",
+    "imageList": [],
+    "type": "Travel",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Join Tour",
+        "url": "https://www.botanicgardens.org.au/whats-on/aboriginal-bush-tucker-tour"
+      }
+    ]
+  },
+  {
+    "cardId": "card_manon_brasserie",
+    "title": "Manon Brasserie Sydney",
+    "description": "Chic French-inspired brasserie offering classic dishes in Sydney’s city centre.",
+    "imageList": [],
+    "type": "Food",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "Visit Website",
+        "url": "https://www.sydney.com/destinations/sydney/sydney-city/city-centre/food-and-drink/manon-brasserie"
+      }
+    ]
+  },
+  {
+    "cardId": "card_musicals_sydney",
+    "title": "Musicals in Sydney",
+    "description": "Stay up to date with current and upcoming musical theatre shows across Sydney.",
+    "imageList": [],
+    "type": "Events",
+    "buttons": [
+      {
+        "buttonType": "Cta",
+        "label": "View Shows",
+        "url": "https://www.sydney.com/things-to-do/arts-and-culture/musicals"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### TL;DR

Added 90+ new activity cards to the Sydney discovery experience, including events, food tours, adventure sports, and cultural attractions.

### What changed?

Added numerous new activity cards to the `discover_sydney.json` file, expanding the available options for users exploring Sydney. The new cards include:

- Entertainment options like Taylor Swift tribute concerts, VR experiences, and comedy clubs
- Adventure activities including jet boating, indoor skydiving, and axe throwing venues
- Culinary experiences such as food tours, specialty restaurants, and distillery visits
- Family-friendly attractions like aquariums, zoos, and amusement parks
- Cultural and sightseeing opportunities including lighthouse tours and harbor cruises

Each card includes a title, description, category type, and relevant CTA buttons with links to booking sites or more information.

### How to test?

1. Load the updated `discover_sydney.json` file in the application
2. Verify that all new cards appear correctly in the discovery interface
3. Check that the cards are properly categorized (Events, Food, Sports, Travel, Kids)
4. Test that CTA buttons link to the correct external websites
5. Ensure descriptions are displayed properly and provide useful information

### Why make this change?

This expansion significantly enhances the Sydney discovery experience by:

1. Providing users with a more comprehensive selection of activities across different interests
2. Including both popular tourist attractions and lesser-known local experiences
3. Offering options at various price points and for different demographics
4. Keeping the content fresh and relevant with current events and seasonal activities
5. Improving user engagement by presenting more personalized activity recommendations