### PR TITLE
Add info_tiles schema for app notifications and alerts

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -42,6 +42,32 @@
         }
       }
     },
+    "/info_tiles": {
+      "get": {
+        "summary": "Get info_tiles schema",
+        "description": "Retrieve the info_tiles schema with structure and examples",
+        "operationId": "getInfo_tiles",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved info_tiles schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/info_tiles"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Schema not found"
+          }
+        }
+      }
+    },
     "/notice": {
       "get": {
         "summary": "Get notice schema",
@@ -136,6 +162,9 @@
                   "properties": {
                     "festivals": {
                       "$ref": "#/components/schemas/festivals"
+                    },
+                    "info_tiles": {
+                      "$ref": "#/components/schemas/info_tiles"
                     },
                     "notice": {
                       "$ref": "#/components/schemas/notice"
@@ -740,6 +769,92 @@
             }
           ]
         }
+      },
+      "info_tiles": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "key",
+            "title",
+            "description",
+            "type"
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "APP_UPDATE",
+                "INFO",
+                "CRITICAL_ALERT"
+              ]
+            },
+            "dismissCtaText": {
+              "type": "string"
+            },
+            "endDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "primaryCta": {
+              "type": "object",
+              "required": [
+                "text",
+                "url"
+              ],
+              "properties": {
+                "text": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          }
+        },
+        "description": "Schema for info_tiles",
+        "example": [
+          {
+            "key": "update_2024",
+            "title": "App Update Available",
+            "description": "A new version of the app is available. Update now for new features.",
+            "type": "APP_UPDATE",
+            "dismissCtaText": "Dismiss",
+            "primaryCta": {
+              "text": "Update",
+              "url": "https://example.com/app"
+            }
+          },
+          {
+            "key": "info_001",
+            "title": "Welcome!",
+            "description": "Thanks for installing our app.",
+            "type": "INFO",
+            "dismissCtaText": "Dismiss",
+            "endDate": "2025-09-01",
+            "primaryCta": {
+              "text": "Learn More",
+              "url": "https://example.com/welcome"
+            }
+          },
+          {
+            "key": "critical_01",
+            "title": "Security Alert",
+            "description": "Please update your app immediately.",
+            "type": "CRITICAL_ALERT"
+          }
+        ]
       },
       "notice": {
         "type": "object",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -28,6 +28,23 @@ paths:
           description: Bad Request
         "404":
           description: Schema not found
+  /info_tiles:
+    get:
+      summary: Get info_tiles schema
+      description: Retrieve the info_tiles schema with structure and examples
+      operationId: getInfo_tiles
+      security: []
+      responses:
+        "200":
+          description: Successfully retrieved info_tiles schema
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/info_tiles"
+        "400":
+          description: Bad Request
+        "404":
+          description: Schema not found
   /notice:
     get:
       summary: Get notice schema
@@ -95,6 +112,8 @@ paths:
                 properties:
                   festivals:
                     $ref: "#/components/schemas/festivals"
+                  info_tiles:
+                    $ref: "#/components/schemas/info_tiles"
                   notice:
                     $ref: "#/components/schemas/notice"
                   park_ride_facilities:
@@ -522,6 +541,67 @@ components:
               - 💛
               - ❤️
             greeting: Reconciliation Week
+    info_tiles:
+      type: array
+      items:
+        type: object
+        required:
+          - key
+          - title
+          - description
+          - type
+        properties:
+          key:
+            type: string
+          title:
+            type: string
+          description:
+            type: string
+          type:
+            type: string
+            enum:
+              - APP_UPDATE
+              - INFO
+              - CRITICAL_ALERT
+          dismissCtaText:
+            type: string
+          endDate:
+            type: string
+            format: date
+          primaryCta:
+            type: object
+            required:
+              - text
+              - url
+            properties:
+              text:
+                type: string
+              url:
+                type: string
+                format: uri
+      description: Schema for info_tiles
+      example:
+        - key: update_2024
+          title: App Update Available
+          description: A new version of the app is available. Update now for new features.
+          type: APP_UPDATE
+          dismissCtaText: Dismiss
+          primaryCta:
+            text: Update
+            url: https://example.com/app
+        - key: info_001
+          title: Welcome!
+          description: Thanks for installing our app.
+          type: INFO
+          dismissCtaText: Dismiss
+          endDate: 2025-09-01
+          primaryCta:
+            text: Learn More
+            url: https://example.com/welcome
+        - key: critical_01
+          title: Security Alert
+          description: Please update your app immediately.
+          type: CRITICAL_ALERT
     notice:
       type: object
       required:

--- a/openapi.json
+++ b/openapi.json
@@ -42,6 +42,32 @@
         }
       }
     },
+    "/info_tiles": {
+      "get": {
+        "summary": "Get info_tiles schema",
+        "description": "Retrieve the info_tiles schema with structure and examples",
+        "operationId": "getInfo_tiles",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved info_tiles schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/info_tiles"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Schema not found"
+          }
+        }
+      }
+    },
     "/notice": {
       "get": {
         "summary": "Get notice schema",
@@ -136,6 +162,9 @@
                   "properties": {
                     "festivals": {
                       "$ref": "#/components/schemas/festivals"
+                    },
+                    "info_tiles": {
+                      "$ref": "#/components/schemas/info_tiles"
                     },
                     "notice": {
                       "$ref": "#/components/schemas/notice"
@@ -740,6 +769,92 @@
             }
           ]
         }
+      },
+      "info_tiles": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "key",
+            "title",
+            "description",
+            "type"
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "APP_UPDATE",
+                "INFO",
+                "CRITICAL_ALERT"
+              ]
+            },
+            "dismissCtaText": {
+              "type": "string"
+            },
+            "endDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "primaryCta": {
+              "type": "object",
+              "required": [
+                "text",
+                "url"
+              ],
+              "properties": {
+                "text": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          }
+        },
+        "description": "Schema for info_tiles",
+        "example": [
+          {
+            "key": "update_2024",
+            "title": "App Update Available",
+            "description": "A new version of the app is available. Update now for new features.",
+            "type": "APP_UPDATE",
+            "dismissCtaText": "Dismiss",
+            "primaryCta": {
+              "text": "Update",
+              "url": "https://example.com/app"
+            }
+          },
+          {
+            "key": "info_001",
+            "title": "Welcome!",
+            "description": "Thanks for installing our app.",
+            "type": "INFO",
+            "dismissCtaText": "Dismiss",
+            "endDate": "2025-09-01",
+            "primaryCta": {
+              "text": "Learn More",
+              "url": "https://example.com/welcome"
+            }
+          },
+          {
+            "key": "critical_01",
+            "title": "Security Alert",
+            "description": "Please update your app immediately.",
+            "type": "CRITICAL_ALERT"
+          }
+        ]
       },
       "notice": {
         "type": "object",

--- a/src/info_tiles.json
+++ b/src/info_tiles.json
@@ -1,0 +1,31 @@
+[
+  {
+    "key": "update_2024",
+    "title": "App Update Available",
+    "description": "A new version of the app is available. Update now for new features.",
+    "type": "APP_UPDATE",
+    "dismissCtaText": "Dismiss",
+    "primaryCta": {
+      "text": "Update",
+      "url": "https://example.com/app"
+    }
+  },
+  {
+    "key": "info_001",
+    "title": "Welcome!",
+    "description": "Thanks for installing our app.",
+    "type": "INFO",
+    "dismissCtaText": "Dismiss",
+    "endDate": "2025-09-01",
+    "primaryCta": {
+      "text": "Learn More",
+      "url": "https://example.com/welcome"
+    }
+  },
+  {
+    "key": "critical_01",
+    "title": "Security Alert",
+    "description": "Please update your app immediately.",
+    "type": "CRITICAL_ALERT"
+  }
+]

--- a/src/info_tiles.schema.json
+++ b/src/info_tiles.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["key", "title", "description", "type"],
+    "properties": {
+      "key": { "type": "string" },
+      "title": { "type": "string" },
+      "description": { "type": "string" },
+      "type": {
+        "type": "string",
+        "enum": ["APP_UPDATE", "INFO", "CRITICAL_ALERT"]
+      },
+      "dismissCtaText": { "type": "string" },
+      "endDate": { "type": "string", "format": "date" },
+      "primaryCta": {
+        "type": "object",
+        "required": ["text", "url"],
+        "properties": {
+          "text": { "type": "string" },
+          "url": { "type": "string", "format": "uri" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### TL;DR

Added new `info_tiles` schema to the API documentation to support in-app notifications and alerts.

### What changed?

- Added a new `/info_tiles` endpoint to retrieve the info_tiles schema
- Created the `info_tiles` schema definition with support for three notification types:
  - APP_UPDATE: For application update notifications
  - INFO: For general informational messages
  - CRITICAL_ALERT: For urgent security or important alerts
- Added schema properties including key, title, description, dismissal text, end date, and call-to-action buttons
- Included example implementations for each notification type
- Added the schema to the API's root endpoint response

### How to test?

1. Make a GET request to `/info_tiles` endpoint to verify the schema is accessible
2. Validate that the schema includes all required fields (key, title, description, type)
3. Check that optional fields (dismissCtaText, endDate, primaryCta) are properly defined
4. Verify the example notifications match the schema requirements
5. Confirm the schema is included in the root endpoint response

### Why make this change?

This addition enables the application to display various types of notifications to users, including app update prompts, general information, and critical alerts. The structured schema ensures consistent implementation across the platform while providing flexibility for different notification needs.